### PR TITLE
[ENGAGE-1320] Fix check have been org invited

### DIFF
--- a/src/views/register/index.vue
+++ b/src/views/register/index.vue
@@ -367,8 +367,12 @@ export default {
 
   computed: {
     haveBeenInvited() {
-      return !!this.$store.state.Account.additionalInformation.data
-        ?.organization?.name;
+      return (
+        !!this.$store.state.Account.additionalInformation.data?.company
+          ?.company_name ||
+        !!this.$store.state.Account.additionalInformation.data?.organization
+          ?.name
+      );
     },
 
     savedOrgName() {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When we invited someone not registered to an org, the user was forced to create +1 org without need. The expected behavior only occurred if the user was already part of a company

### Summary of Changes
 - Added the check if the user has an invitation to a company or organization instead of looking only at the company