### PR TITLE
[ENGAGE-2015] - Fix profile dropdown not close on click iframes

### DIFF
--- a/src/components/Topbar/ProfileDropdown.vue
+++ b/src/components/Topbar/ProfileDropdown.vue
@@ -1,8 +1,10 @@
 <template>
   <UnnnicDropdown
+    ref="profileDropdown"
     position="bottom-left"
     class="dropdown"
     :open="isProfileDropdownOpen"
+    @update:open="isProfileDropdownOpen = $event"
   >
     <template #trigger>
       <section
@@ -89,6 +91,7 @@ import { computed, getCurrentInstance, ref } from 'vue';
 import ProfilePictureDefault from './ProfilePictureDefault.vue';
 import ProfileLanguageSelector from './ProfileLanguageSelector.vue';
 import i18n from '@/utils/plugins/i18n.js';
+import { onClickOutside } from '@vueuse/core';
 
 import {
   ORG_ROLE_ADMIN,
@@ -108,6 +111,16 @@ const keycloak = use('keycloak');
 
 const photoWithError = ref(false);
 const isProfileDropdownOpen = ref(false);
+
+const profileDropdown = ref(null);
+
+onClickOutside(
+  profileDropdown,
+  () => {
+    isProfileDropdownOpen.value = false;
+  },
+  { detectIframe: true },
+);
 
 const firstName = computed(() => {
   return getProfileProperty('first_name');


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When clicking on the content of the iframes, the profile dropdown remained active, which is undesirable behavior

### Summary of Changes
<!--- Describe your changes in detail -->
- Add onClickOutside logic to prevent unwanted behavior

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->

https://github.com/user-attachments/assets/22c36f87-13af-47d0-b6d3-c1a3e1713d46


