### PR TITLE
fix: Human support settings view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.29.7] - 2026-04-14
+
+### Fixed
+
+- fix: restrict settings access for chat users to only display chats settings
+
 ## [2.29.6] - 2026-04-13
 
 ### Changed

--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -21,12 +21,13 @@
     />
 
     <SettingsWorkspace
-      v-if="$route.name === 'settingsProject'"
+      v-if="$route.name === 'settingsProject' && !hideModulesButChats"
       class="page"
     />
 
     <component
       :is="externalSystemComponent"
+      v-if="!hideModulesButChats"
       id="integrations-settings-iframe"
       ref="system-integrations-settings"
       :routes="['settingsChannels']"
@@ -181,6 +182,14 @@ export default {
       immediate: true,
 
       handler() {
+        if (this.hideModulesButChats && this.$route.name !== 'settingsChats') {
+          this.$router.replace({
+            name: 'settingsChats',
+            params: { internal: ['init'] },
+          });
+          return;
+        }
+
         this.showOverlay = false;
         this.$nextTick(() => {
           setTimeout(() => {
@@ -205,7 +214,10 @@ export default {
         this.$refs['system-integrations-settings']?.reset();
         this.$refs['system-chats-settings']?.reset();
 
-        this.$router.push({ name: 'settingsProject' });
+        const targetRoute = this.hideModulesButChats
+          ? 'settingsChats'
+          : 'settingsProject';
+        this.$router.push({ name: targetRoute });
       },
     },
   },


### PR DESCRIPTION
## Description
### Type of Change

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Tests
* [ ] Other

### Motivation and Context

Users with the `PROJECT_ROLE_CHATUSER` role (human attendance / live desk) could access the full project settings page (workspace configuration and channel integrations) instead of being restricted to only the chats settings.

### Summary of Changes

All changes in `src/views/settings.vue`:

- **Template guards**: Added `v-if="!hideModulesButChats"` to `SettingsWorkspace` and the integrations settings iframe so they are never rendered for chat users, even if the route matches.
- **Route redirect**: Added an early check in the `$route.fullPath` watcher that redirects chat users to `settingsChats` whenever they land on `settingsProject` or `settingsChannels` (covers direct URL access and the router's default redirect).
- **Project change watcher**: Updated the `$route.params.projectUuid` watcher to navigate to `settingsChats` instead of `settingsProject` when the user has the chat user role.