### PR TITLE
fix: Scope user list leave/remove copy to project context

### DIFF
--- a/src/components/users/UserListItem.vue
+++ b/src/components/users/UserListItem.vue
@@ -47,7 +47,11 @@
         v-if="isMe || !disabled"
         side="left"
         enabled
-        :text="isMe ? $t('orgs.users.leave') : $t('orgs.users.remove')"
+        :text="
+          isMe
+            ? $t('orgs.users.leave_project.title')
+            : $t('orgs.users.remove_from_project.title')
+        "
         class="delete-button"
       >
         <UnnnicIconSvg
@@ -262,20 +266,22 @@ export default {
       let validate = null;
 
       if (this.isMe) {
-        title = this.$t('orgs.leave.title');
-        description = this.$t('orgs.leave_description');
+        title = this.$t('orgs.users.leave_project.title');
+        description = this.$t('orgs.users.leave_project.description', {
+          name: this.projectName,
+        });
         validate = {
           label: this.$t('orgs.leave.confirm_with_name', {
             name: this.projectName,
           }),
-          placeholder: this.$t('orgs.leave.confirm_with_name_placeholder'),
+          placeholder: this.$t('orgs.users.leave_project.confirm_placeholder'),
           text: this.projectName,
         };
       } else {
-        title = this.$t('orgs.remove_member');
-        description = this.$t('orgs.remove_member_description', {
+        title = this.$t('orgs.users.remove_from_project.title');
+        description = this.$t('orgs.users.remove_from_project.description', {
           user: this.name,
-          org: this.projectName,
+          project: this.projectName,
         });
       }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -666,7 +666,16 @@
       "left_description": "Your leaving the organization was successfully accomplished.",
       "remove": "Remove from organization",
       "already_added": "User already added",
-      "already_in": "User is already in the organization"
+      "already_in": "User is already in the organization",
+      "leave_project": {
+        "title": "Leave project",
+        "description": "Are you sure you want to leave the <b>{name}</b> project?",
+        "confirm_placeholder": "Project name"
+      },
+      "remove_from_project": {
+        "title": "Remove from project",
+        "description": "Are you sure you want to remove <b>{user}</b> from <b>{project}</b>?"
+      }
     },
     "config": "Settings",
     "security": "Security",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -666,7 +666,16 @@
       "left_description": "Su salida de la organización se llevó a cabo con éxito.",
       "remove": "Eliminar de la organización",
       "already_added": "Usuario ya añadido",
-      "already_in": "Ya está en la organización"
+      "already_in": "Ya está en la organización",
+      "leave_project": {
+        "title": "Dejar el proyecto",
+        "description": "¿Realmente deseas dejar el proyecto <b>{name}</b>?",
+        "confirm_placeholder": "Nombre del proyecto"
+      },
+      "remove_from_project": {
+        "title": "Eliminar del proyecto",
+        "description": "¿Realmente deseas eliminar a <b>{user}</b> del proyecto <b>{project}</b>?"
+      }
     },
     "config": "Ajustes",
     "security": "Seguridad",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -666,7 +666,16 @@
       "left_description": "Sua saída da organização foi realizada com sucesso.",
       "remove": "Remover da organização",
       "already_added": "Usuário já adicionado",
-      "already_in": "O usuário já está na organização"
+      "already_in": "O usuário já está na organização",
+      "leave_project": {
+        "title": "Sair do projeto",
+        "description": "Tem certeza de que deseja sair do projeto <b>{name}</b>?",
+        "confirm_placeholder": "Nome do projeto"
+      },
+      "remove_from_project": {
+        "title": "Remover do projeto",
+        "description": "Tem certeza de que deseja remover <b>{user}</b> do projeto <b>{project}</b>?"
+      }
     },
     "config": "Configurações",
     "security": "Segurança",


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
`UserListItem` is rendered only at the project level, but its delete tooltip and confirmation modal showed organization-scoped strings. The leave description also referenced an unpassed `{name}` placeholder (rendered literally in the UI), and the remove description hard-coded "organization" in `pt_br` / `es`.

### Summary of Changes
- Added nested `orgs.users.leave_project` and `orgs.users.remove_from_project` objects (`title`, `description`, `confirm_placeholder`) in `en`, `pt_br` and `es`, mirroring the existing `orgs.delete` / `orgs.leave` shape.
- Wired `UserListItem`'s tooltip and `onDelete` modal to the new keys, passing `name` / `user` / `project` params so interpolation works.
- Existing org-scoped keys are untouched — still consumed by `orgList.vue`, `UserManagement.vue`, `OrgCard.vue` and `orgListItem.vue`.

Made with [Cursor](https://cursor.com)