### PR TITLE
fix: Show required error on project description when empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [2.29.8] - 2026-04-22
+
+### Fixed
+
+- fix: Show required error on project description when empty
+- fix: Scope user list leave/remove copy to project context
+
 ## [2.29.7] - 2026-04-14
 
 ### Fixed

--- a/src/views/settings/ProjectPreferences.vue
+++ b/src/views/settings/ProjectPreferences.vue
@@ -6,7 +6,10 @@
         :label="$t('orgs.create.project_name')"
       />
 
-      <ProjectDescriptionTextarea v-model="description" />
+      <ProjectDescriptionTextarea
+        v-model="description"
+        :error="descriptionError"
+      />
 
       <UnnnicFormElement :label="$t('orgs.create.time_zone')">
         <UnnnicSelectSmart
@@ -54,11 +57,13 @@
 import { ref, computed, watch, onMounted } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter, onBeforeRouteLeave } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 import { useProjectSettings } from '@/composables/useProjectSettings';
 import ProjectDescriptionTextarea from '@/views/projects/form/DescriptionTextarea.vue';
 
 const store = useStore();
 const router = useRouter();
+const { t } = useI18n();
 
 const {
   loading,
@@ -84,6 +89,10 @@ const selectedTimezoneValue = computed(() =>
 
 const selectedLanguageValue = computed(() =>
   selectedLanguage.value ? [selectedLanguage.value] : [],
+);
+
+const descriptionError = computed(() =>
+  !description.value ? t('errors.required') : false,
 );
 
 const isSaveButtonDisabled = computed(() => {


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The project description field in workspace settings is required to save, but when it was empty the form gave no feedback — the save button was disabled with no visible reason.

### Summary of Changes
- Added a `descriptionError` computed in `ProjectPreferences.vue` that returns the `errors.required` message when `description` is empty.
- Wired it to `ProjectDescriptionTextarea` via its existing `error` prop, so the field switches to its error state and shows the required message.

Made with [Cursor](https://cursor.com)