### PR TITLE
🐛 Disable Keycloak Login Iframe Check in Development

### DIFF
--- a/src/services/Keycloak.js
+++ b/src/services/Keycloak.js
@@ -57,6 +57,7 @@ export default {
       useNonce: false,
       scope: 'email profile openid offline_access',
       pkceMethod: 'S256',
+      checkLoginIframe: process.env.NODE_ENV === 'production',
       ...toInsert,
     });
 


### PR DESCRIPTION
## Description

### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When running the app locally and logging in via Keycloak, navigating between pages would immediately trigger a new login redirect, effectively making the session unusable in development.

The root cause is that `keycloak.init()` defaults `checkLoginIframe` to `true`, which starts a hidden background iframe that periodically polls the Keycloak server's session endpoint to detect SSO session changes. In local development, this silently fails because:

1. The app runs on `http://localhost` while Keycloak is on a different origin (`accounts.weni.ai`), and modern browsers block third-party cookies (`SameSite=Lax/Strict`), making the iframe unable to verify the session.
2. Short SSO session timeouts on staging can cause the iframe to immediately report the session as expired.

When the iframe check reports the session as invalid, `keycloak.authenticated` is set to `false` by the library. On the next route navigation, the router's `beforeEach` guard reads this as unauthenticated and calls `keycloak.login()`, redirecting the user back to the login page.

### Summary of Changes
- Set `checkLoginIframe` dynamically based on `NODE_ENV` in `keycloak.init()`:
  - `false` in development — disables the background iframe session check, preventing cross-origin cookie failures from invalidating the local session
  - `true` in production — keeps real-time SSO session detection fully functional

Token refresh and server-side JWT validation are unaffected by this change.