### PR TITLE
🐛 Federated Module Lifecycle and Integrations Iframe Deep Links

### DIFF
--- a/src/components/ExternalSystem.vue
+++ b/src/components/ExternalSystem.vue
@@ -504,7 +504,13 @@ export default {
         const apiUrl = this.urls.integrations;
         if (!apiUrl) return null;
 
-        this.setSrc(`${apiUrl}${uuid}/${flow_organization}${this.nextParam}`);
+        let next = this.nextParam;
+
+        if (next) {
+          next = next.replace(/(\?next=)\/?(.+)/, '$1/$2');
+        }
+
+        this.setSrc(`${apiUrl}${uuid}/${flow_organization}${next}`);
       } catch (e) {
         return e;
       }

--- a/src/composables/useFederatedModule.js
+++ b/src/composables/useFederatedModule.js
@@ -116,6 +116,15 @@ export function useFederatedModule(config) {
       return;
     }
 
+    const initialRoute = getInitialModuleRoute();
+
+    // Deep links must use the iframe loader (?next=) so the remote app opens the
+    // correct page; module federation mount does not support that URL contract.
+    if (iframeFallback && initialRoute?.path) {
+      fallbackToIframe();
+      return;
+    }
+
     isMounting.value = true;
 
     const mountApp = await tryImportWithRetries(importFn, importPath);
@@ -129,8 +138,6 @@ export function useFederatedModule(config) {
       isMounting.value = false;
       return;
     }
-
-    const initialRoute = getInitialModuleRoute();
 
     const { app: mountedApp, router: mountedRouter } = await mountApp({
       containerId,

--- a/src/composables/useFederatedModule.js
+++ b/src/composables/useFederatedModule.js
@@ -62,8 +62,28 @@ export function useFederatedModule(config) {
   const iframeRef = ref(null);
   const isMounting = ref(false);
   const unmountTimeoutId = ref(null);
+  let mountGeneration = 0;
 
-  const isModuleRoute = computed(() => routeNames.includes(route?.name));
+  const isModuleRoute = computed(() => isActiveModuleRoute(route?.name));
+
+  function isActiveModuleRoute(routeName) {
+    if (!routeName) {
+      return false;
+    }
+
+    if (routeNames.includes(routeName)) {
+      return true;
+    }
+
+    return routeName.includes(moduleName);
+  }
+
+  function teardownRouterSync() {
+    if (routerUnsubscribe.value) {
+      routerUnsubscribe.value();
+      routerUnsubscribe.value = null;
+    }
+  }
 
   const { getInitialModuleRoute } = useModuleUpdateRoute(
     routeNameForUpdateRoute || moduleName,
@@ -77,15 +97,17 @@ export function useFederatedModule(config) {
    * navigation so the host router can stay in sync.
    */
   function setupRouterSync() {
-    if (routerUnsubscribe.value) {
-      routerUnsubscribe.value();
-    }
+    teardownRouterSync();
 
     if (!moduleRouter.value) {
       return;
     }
 
     routerUnsubscribe.value = moduleRouter.value.afterEach((to) => {
+      if (!isActiveModuleRoute(route?.name) || !unref(modelValue)) {
+        return;
+      }
+
       window.dispatchEvent(
         new CustomEvent('updateRoute', {
           detail: {
@@ -109,9 +131,16 @@ export function useFederatedModule(config) {
       return;
     }
 
+    const generation = ++mountGeneration;
+
     // In iframe mode, initialize the iframe and return early
     if (useIframe.value) {
       await nextTick();
+
+      if (generation !== mountGeneration || !unref(modelValue)) {
+        return;
+      }
+
       iframeRef.value?.init();
       return;
     }
@@ -128,6 +157,11 @@ export function useFederatedModule(config) {
     isMounting.value = true;
 
     const mountApp = await tryImportWithRetries(importFn, importPath);
+
+    if (generation !== mountGeneration || !unref(modelValue)) {
+      isMounting.value = false;
+      return;
+    }
 
     if (!mountApp) {
       if (iframeFallback) {
@@ -181,10 +215,7 @@ export function useFederatedModule(config) {
       sharedStore.setIsActiveFederatedModule(moduleName, false);
     }
 
-    if (routerUnsubscribe.value) {
-      routerUnsubscribe.value();
-      routerUnsubscribe.value = null;
-    }
+    teardownRouterSync();
 
     if (useIframe.value) {
       iframeRef.value?.reset();
@@ -210,12 +241,18 @@ export function useFederatedModule(config) {
 
   // --- Watchers ---
 
-  // Auto-mount when modelValue becomes true
+  // Auto-mount when modelValue becomes true; cancel in-flight mounts when hidden
   watch(
     () => unref(modelValue),
-    () => {
-      if (unref(modelValue) && !app.value) {
+    (isActive) => {
+      if (isActive && !app.value) {
         mount();
+        return;
+      }
+
+      if (!isActive) {
+        mountGeneration += 1;
+        teardownRouterSync();
       }
     },
     { immediate: true },
@@ -240,16 +277,13 @@ export function useFederatedModule(config) {
     watch(
       () => route?.name,
       (newRoute, oldRoute) => {
-        const wasModuleRoute = routeNames.includes(oldRoute);
-        const isCurrentModuleRoute = routeNames.includes(newRoute);
+        const wasOnModule = isActiveModuleRoute(oldRoute);
+        const isOnModule = isActiveModuleRoute(newRoute);
 
         // Leaving the module route
-        if (
-          wasModuleRoute &&
-          !isCurrentModuleRoute &&
-          app.value &&
-          !useIframe.value
-        ) {
+        if (wasOnModule && !isOnModule && app.value && !useIframe.value) {
+          teardownRouterSync();
+
           if (activeModuleTracking) {
             sharedStore.setIsActiveFederatedModule(moduleName, false);
           }
@@ -262,7 +296,7 @@ export function useFederatedModule(config) {
         }
 
         // Entering the module route
-        if (!wasModuleRoute && isCurrentModuleRoute) {
+        if (!wasOnModule && isOnModule) {
           if (unmountTimeoutId.value) {
             clearTimeout(unmountTimeoutId.value);
             unmountTimeoutId.value = null;
@@ -274,6 +308,8 @@ export function useFederatedModule(config) {
 
           if (!app.value && unref(modelValue)) {
             mount();
+          } else if (app.value && moduleRouter.value) {
+            setupRouterSync();
           }
         }
       },

--- a/src/composables/useModuleUpdateRoute.js
+++ b/src/composables/useModuleUpdateRoute.js
@@ -15,6 +15,10 @@ export function useModuleUpdateRoute(routeName) {
       return;
     }
 
+    if (!route?.name?.includes?.(routeName)) {
+      return;
+    }
+
     const path = event.detail.path
       .split('/')
       .slice(1)

--- a/src/composables/useModuleUpdateRoute.js
+++ b/src/composables/useModuleUpdateRoute.js
@@ -38,7 +38,18 @@ export function useModuleUpdateRoute(routeName) {
       ? internal.join('/')
       : internal || '';
 
-    return pathPart ? { path: pathPart, query: route?.query || {} } : undefined;
+    if (
+      !pathPart ||
+      pathPart === 'init' ||
+      pathPart === 'init/force' ||
+      pathPart.startsWith('r/')
+    ) {
+      return undefined;
+    }
+
+    const path = pathPart.startsWith('/') ? pathPart : `/${pathPart}`;
+
+    return { path, query: route?.query || {} };
   }
 
   onMounted(() => {


### PR DESCRIPTION
## Description

### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context

Two related issues affected federated modules and iframe-based settings:

**1. Integrations (Settings → Channels) deep links**

When opening a URL such as `/projects/:uuid/settings/channels/apps/my/configured/...`, the integrations iframe loaded but did not receive the internal path as a `?next=` query parameter. The remote app expects `?next=/apps/...` to land on the correct screen. Without a leading slash, the parameter was also ignored in some cases.

**2. Insights hijacking the host route after navigation**

On project entry, Insights starts loading by default (`ProjectHomeRedirect`). Module Federation import is slow. If the user switched to another module (e.g. Chats) before the import finished, Insights would still mount in the background, sync its internal router to the host via `updateRoute`, and force the browser back to Insights several seconds later.

### Summary of Changes

**Integrations iframe (`ExternalSystem.vue`, `useFederatedModule.js`, `useModuleUpdateRoute.js`)**
- Normalize `?next=` in `integrationsRedirect()` with a leading slash (same pattern as Chats/Insights iframes).
- For deep links (`:internal+` beyond `init`), prefer the iframe loader when `iframeFallback` is enabled, so the integrations URL contract (`?next=`) is used instead of a Module Federation mount that does not support it.
- Extend `getInitialModuleRoute()` to ignore `init` / `init/force` / `r/` paths and return a normalized path for real deep links.

**Stale Insights route sync (`useFederatedModule.js`, `useModuleUpdateRoute.js`)**
- Introduce `mountGeneration` to cancel in-flight mounts when the user leaves the module before the remote import completes.
- Tear down the federated module’s `afterEach` router sync as soon as the user leaves the module route (not only on delayed unmount).
- Only dispatch `updateRoute` from the remote router while the host is still on that module and `modelValue` is true.
- Ignore `updateRoute` events in `useModuleUpdateRoute` when the host route no longer belongs to that module (prevents late Insights events from changing the URL).

### Demonstration

**Integrations deep link**
1. Open  
   `/projects/{uuid}/settings/channels/apps/my/configured/wwc/{id}`
2. Confirm the integrations iframe request includes  
   `?next=/apps/my/configured/wwc/{id}`
3. Confirm the integrations UI opens on the expected page.

**Insights redirect**
1. Open a project (default redirect to Insights starts loading).
2. Immediately navigate to Chats or another module.
3. Wait for the Insights bundle to finish loading.
4. Confirm the URL stays on the selected module and does not jump back to Insights.