### PR TITLE
🔧 Improve Maintainability of Federated Module Route Synchronization

### DIFF
--- a/src/components/SystemIntegrations.vue
+++ b/src/components/SystemIntegrations.vue
@@ -16,6 +16,7 @@ defineProps({
     importPath="integrations/main"
     containerId="integrations-app"
     :routeNames="['settingsChannels']"
+    :updateRoutePathPrefixes="['integrations']"
     forceRemountEvent="forceRemountIntegrations"
     :modelValue="modelValue"
     systemClass="system-integrations__system"

--- a/src/components/__tests__/SystemIntegrations.spec.js
+++ b/src/components/__tests__/SystemIntegrations.spec.js
@@ -138,6 +138,10 @@ describe('SystemIntegrations', () => {
     );
   });
 
+  it('passes integrations updateRoute path prefixes to FederatedModule', () => {
+    expect(getFm().props('updateRoutePathPrefixes')).toEqual(['integrations']);
+  });
+
   it('passes deep link path as initialRoute when mounting', async () => {
     await router.push({
       name: 'settingsChannels',

--- a/src/components/modules/FederatedModule.vue
+++ b/src/components/modules/FederatedModule.vue
@@ -66,6 +66,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  updateRoutePathPrefixes: {
+    type: Array,
+    default: () => [],
+  },
 });
 
 const {
@@ -89,6 +93,7 @@ const {
   iframeFallback: props.iframeFallback,
   inactivityTimeout: props.inactivityTimeout,
   activeModuleTracking: props.activeModuleTracking,
+  updateRoutePathPrefixes: props.updateRoutePathPrefixes,
 });
 
 defineExpose({

--- a/src/composables/__tests__/useFederatedModule.spec.js
+++ b/src/composables/__tests__/useFederatedModule.spec.js
@@ -1,0 +1,180 @@
+import { defineComponent } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ref } from 'vue';
+import { useFederatedModule } from '../useFederatedModule';
+
+const { mockRouterAfterEach, mockRouterUnsubscribe, mockMountApp } = vi.hoisted(
+  () => {
+    const mockRouterAfterEach = vi.fn();
+    const mockRouterUnsubscribe = vi.fn();
+    const mockMountApp = vi.fn();
+
+    return {
+      mockRouterAfterEach,
+      mockRouterUnsubscribe,
+      mockMountApp,
+    };
+  },
+);
+
+const routeRef = ref({
+  name: 'settingsChannels',
+  params: { internal: ['init'] },
+  query: {},
+});
+const modelValueRef = ref(true);
+
+vi.mock('vue-router', () => ({
+  useRoute: () => routeRef.value,
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+
+vi.mock('@/utils/moduleFederation', () => ({
+  tryImportWithRetries: vi.fn().mockResolvedValue(mockMountApp),
+}));
+
+vi.mock('@/store/Shared', () => ({
+  useSharedStore: vi.fn().mockReturnValue({
+    current: {
+      project: { uuid: 'test-uuid' },
+    },
+    auth: {
+      token: 'mock-token',
+    },
+    setIsActiveFederatedModule: vi.fn(),
+  }),
+}));
+
+function mountComposable(configOverrides = {}) {
+  let afterEachCallback;
+
+  mockRouterAfterEach.mockImplementation((callback) => {
+    afterEachCallback = callback;
+    return mockRouterUnsubscribe;
+  });
+
+  mockMountApp.mockResolvedValue({
+    app: { unmount: vi.fn() },
+    router: {
+      afterEach: mockRouterAfterEach,
+      replace: vi.fn(),
+    },
+  });
+
+  const Wrapper = defineComponent({
+    setup() {
+      useFederatedModule({
+        moduleName: 'settingsChannels',
+        importFn: () => Promise.resolve(mockMountApp),
+        importPath: 'integrations/main',
+        containerId: 'integrations-app',
+        routeNames: ['settingsChannels'],
+        forceRemountEvent: 'forceRemountIntegrations',
+        modelValue: modelValueRef,
+        updateRoutePathPrefixes: ['integrations'],
+        ...configOverrides,
+      });
+
+      return () => null;
+    },
+  });
+
+  const wrapper = mount(Wrapper);
+
+  return { wrapper, getAfterEachCallback: () => afterEachCallback };
+}
+
+describe('useFederatedModule setupRouterSync', () => {
+  let wrapper;
+  let getAfterEachCallback;
+  let dispatchEventSpy;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    modelValueRef.value = true;
+    routeRef.value = {
+      name: 'settingsChannels',
+      params: { internal: ['init'] },
+      query: {},
+    };
+
+    dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+
+    ({ wrapper, getAfterEachCallback } = mountComposable());
+    await flushPromises();
+  });
+
+  afterEach(() => {
+    dispatchEventSpy.mockRestore();
+    wrapper?.unmount();
+  });
+
+  it('dispatches updateRoute when host has no deep link', () => {
+    const afterEachCallback = getAfterEachCallback();
+
+    afterEachCallback({
+      path: '/discovery',
+      query: { filter: 'value1' },
+    });
+
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'updateRoute',
+        detail: {
+          path: 'settingsChannels/discovery',
+          query: { filter: 'value1' },
+        },
+      }),
+    );
+  });
+
+  it('skips default route sync while host deep link is not yet matched', async () => {
+    wrapper.unmount();
+    routeRef.value.params.internal = ['apps', 'my'];
+
+    ({ wrapper, getAfterEachCallback } = mountComposable());
+    await flushPromises();
+
+    const afterEachCallback = getAfterEachCallback();
+
+    afterEachCallback({
+      path: '/init',
+      query: {},
+    });
+
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
+  });
+
+  it('stops skipping once module sync matches host deep link', async () => {
+    wrapper.unmount();
+    routeRef.value.params.internal = ['apps', 'my'];
+
+    ({ wrapper, getAfterEachCallback } = mountComposable());
+    await flushPromises();
+
+    const afterEachCallback = getAfterEachCallback();
+
+    afterEachCallback({
+      path: '/apps/my',
+      query: {},
+    });
+
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
+
+    afterEachCallback({
+      path: '/apps/other',
+      query: { tab: '1' },
+    });
+
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'updateRoute',
+        detail: {
+          path: 'settingsChannels/apps/other',
+          query: { tab: '1' },
+        },
+      }),
+    );
+  });
+});

--- a/src/composables/__tests__/useModuleUpdateRoute.spec.js
+++ b/src/composables/__tests__/useModuleUpdateRoute.spec.js
@@ -2,10 +2,8 @@ import { defineComponent } from 'vue';
 import { mount } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ref } from 'vue';
-import {
-  normalizeInternalPath,
-  useModuleUpdateRoute,
-} from '../useModuleUpdateRoute';
+import { normalizeInternalPath } from '@/utils/normalizeInternalPath';
+import { useModuleUpdateRoute } from '../useModuleUpdateRoute';
 
 const mockReplace = vi.fn();
 const routeRef = ref({
@@ -19,12 +17,12 @@ vi.mock('vue-router', () => ({
   useRoute: () => routeRef.value,
 }));
 
-function mountComposable() {
+function mountComposable(options = {}) {
   let api;
 
   const Wrapper = defineComponent({
     setup() {
-      api = useModuleUpdateRoute('settingsChannels');
+      api = useModuleUpdateRoute('settingsChannels', options);
       return () => null;
     },
   });
@@ -57,7 +55,9 @@ describe('useModuleUpdateRoute', () => {
       query: {},
     };
 
-    ({ wrapper, api: { getInitialModuleRoute } } = mountComposable());
+    ({ wrapper, api: { getInitialModuleRoute } } = mountComposable({
+      eventPathPrefixes: ['integrations'],
+    }));
   });
 
   afterEach(() => {
@@ -97,20 +97,14 @@ describe('useModuleUpdateRoute', () => {
     });
   });
 
-  it('does not replace a deep link with init from module sync', () => {
+  it('ignores integrations-prefixed events without configured prefixes', () => {
+    wrapper.unmount();
+
+    ({ wrapper } = mountComposable());
+
     window.dispatchEvent(
       new CustomEvent('updateRoute', {
-        detail: { path: 'settingsChannels/init', query: {} },
-      }),
-    );
-
-    expect(mockReplace).not.toHaveBeenCalled();
-  });
-
-  it('does not replace a deep link with apps/discovery from module sync', () => {
-    window.dispatchEvent(
-      new CustomEvent('updateRoute', {
-        detail: { path: 'settingsChannels/apps/discovery', query: {} },
+        detail: { path: 'integrations/discovery', query: {} },
       }),
     );
 

--- a/src/composables/useFederatedModule.js
+++ b/src/composables/useFederatedModule.js
@@ -12,6 +12,10 @@ import { useRoute } from 'vue-router';
 import { tryImportWithRetries } from '@/utils/moduleFederation';
 import { useSharedStore } from '@/store/Shared';
 import { useModuleUpdateRoute } from '@/composables/useModuleUpdateRoute';
+import {
+  normalizeInternalPath,
+  parseInternalFromEventPath,
+} from '@/utils/normalizeInternalPath';
 
 /**
  * Composable for managing federated module lifecycle.
@@ -32,6 +36,7 @@ import { useModuleUpdateRoute } from '@/composables/useModuleUpdateRoute';
  * @param {number|null} [config.inactivityTimeout=null] - Ms before unmount on inactivity (null = disabled)
  * @param {boolean} [config.activeModuleTracking=false] - Track active state via sharedStore
  * @param {string} [config.routeNameForUpdateRoute] - Override route name for useModuleUpdateRoute (defaults to moduleName)
+ * @param {string[]} [config.updateRoutePathPrefixes=[]] - Additional path prefixes accepted in updateRoute events
  * @returns {Object} Reactive state and lifecycle functions for the federated module
  */
 export function useFederatedModule(config) {
@@ -48,6 +53,7 @@ export function useFederatedModule(config) {
     inactivityTimeout = null,
     activeModuleTracking = false,
     routeNameForUpdateRoute,
+    updateRoutePathPrefixes = [],
   } = config;
 
   const route = useRoute();
@@ -62,12 +68,16 @@ export function useFederatedModule(config) {
   const iframeRef = ref(null);
   const isMounting = ref(false);
   const unmountTimeoutId = ref(null);
+  const skipInitialRouteSync = ref(false);
+
+  const routeNameForSync = routeNameForUpdateRoute || moduleName;
+  const syncPathPrefixes = [routeNameForSync, ...updateRoutePathPrefixes];
 
   const isModuleRoute = computed(() => routeNames.includes(route?.name));
 
-  const { getInitialModuleRoute } = useModuleUpdateRoute(
-    routeNameForUpdateRoute || moduleName,
-  );
+  const { getInitialModuleRoute } = useModuleUpdateRoute(routeNameForSync, {
+    eventPathPrefixes: updateRoutePathPrefixes,
+  });
 
   // --- Core Functions ---
 
@@ -89,6 +99,15 @@ export function useFederatedModule(config) {
   }
 
   /**
+   * @param {string} modulePath
+   * @returns {string}
+   */
+  function getSyncedInternalPath(modulePath) {
+    const eventPath = buildUpdateRoutePath(modulePath);
+    return parseInternalFromEventPath(eventPath, syncPathPrefixes).join('/');
+  }
+
+  /**
    * Set up router synchronization between the module's internal router and the
    * host application. Dispatches an 'updateRoute' CustomEvent on every module
    * navigation so the host router can stay in sync.
@@ -103,6 +122,20 @@ export function useFederatedModule(config) {
     }
 
     routerUnsubscribe.value = moduleRouter.value.afterEach((to) => {
+      const syncedInternal = getSyncedInternalPath(to.path);
+      const hostInternal = normalizeInternalPath(route?.params?.internal);
+
+      if (skipInitialRouteSync.value) {
+        if (syncedInternal === hostInternal) {
+          skipInitialRouteSync.value = false;
+        }
+        return;
+      }
+
+      if (syncedInternal && syncedInternal === hostInternal) {
+        return;
+      }
+
       window.dispatchEvent(
         new CustomEvent('updateRoute', {
           detail: {
@@ -148,6 +181,7 @@ export function useFederatedModule(config) {
     }
 
     const initialRoute = getInitialModuleRoute();
+    skipInitialRouteSync.value = !!initialRoute?.path;
 
     const { app: mountedApp, router: mountedRouter } = await mountApp({
       containerId,

--- a/src/composables/useModuleUpdateRoute.js
+++ b/src/composables/useModuleUpdateRoute.js
@@ -1,80 +1,24 @@
 import { onMounted, onUnmounted } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 
-/** Default landing paths reported by federated modules on mount. */
-const MODULE_DEFAULT_HOME_PATHS = new Set(['init', 'apps/discovery']);
+import {
+  normalizeInternalPath,
+  parseInternalFromEventPath,
+} from '@/utils/normalizeInternalPath';
 
-/**
- * Strips the host-only `r/` remount prefix from internal path segments.
- * @param {string|string[]|undefined} internal
- * @returns {string}
- */
-export function normalizeInternalPath(internal) {
-  const pathPart = Array.isArray(internal)
-    ? internal.join('/')
-    : internal || '';
-
-  if (pathPart.startsWith('r/')) {
-    return pathPart.slice(2);
-  }
-
-  return pathPart;
-}
-
-/**
- * @param {string} routeName
- * @returns {string[]}
- */
-function getAcceptedPathPrefixes(routeName) {
-  const prefixes = [routeName];
-
-  if (routeName === 'settingsChannels') {
-    prefixes.push('integrations');
-  }
-
-  return prefixes;
-}
-
-/**
- * @param {string} eventPath
- * @param {string[]} prefixes
- * @returns {string[]}
- */
-function parseInternalFromEventPath(eventPath, prefixes) {
-  if (!eventPath) {
-    return [];
-  }
-
-  for (const prefix of prefixes) {
-    if (eventPath === prefix) {
-      return [];
-    }
-
-    if (eventPath.startsWith(`${prefix}/`)) {
-      return eventPath.slice(prefix.length + 1).split('/').filter(Boolean);
-    }
-  }
-
-  return [];
-}
-
-/**
- * @param {string} path
- * @returns {boolean}
- */
-function isModuleDefaultHome(path) {
-  return MODULE_DEFAULT_HOME_PATHS.has(path);
-}
+export { normalizeInternalPath, parseInternalFromEventPath };
 
 /**
  * Composable to handle updateRoute window events and extract initial module route
  * @param {string} routeName - The name of the route to navigate to
+ * @param {Object} [options]
+ * @param {string[]} [options.eventPathPrefixes=[]] - Additional path prefixes accepted in updateRoute events
  * @returns {object} - Object containing getInitialModuleRoute function
  */
-export function useModuleUpdateRoute(routeName) {
+export function useModuleUpdateRoute(routeName, { eventPathPrefixes = [] } = {}) {
   const router = useRouter();
   const route = useRoute();
-  const acceptedPrefixes = getAcceptedPathPrefixes(routeName);
+  const acceptedPrefixes = [routeName, ...eventPathPrefixes];
 
   const handleUpdateRoute = (event) => {
     const eventPath = event.detail?.path;
@@ -93,19 +37,6 @@ export function useModuleUpdateRoute(routeName) {
     }
 
     if (!path.length) {
-      return;
-    }
-
-    const incomingPath = path.join('/');
-    const currentPath = normalizeInternalPath(route?.params?.internal);
-
-    // Keep deep links when the federated app reports its default route on mount.
-    if (
-      isModuleDefaultHome(incomingPath) &&
-      currentPath &&
-      !isModuleDefaultHome(currentPath) &&
-      !currentPath.startsWith('r/')
-    ) {
       return;
     }
 

--- a/src/utils/normalizeInternalPath.js
+++ b/src/utils/normalizeInternalPath.js
@@ -1,0 +1,39 @@
+/**
+ * Strips the host-only `r/` remount prefix from internal path segments.
+ * @param {string|string[]|undefined} internal
+ * @returns {string}
+ */
+export function normalizeInternalPath(internal) {
+  const pathPart = Array.isArray(internal)
+    ? internal.join('/')
+    : internal || '';
+
+  if (pathPart.startsWith('r/')) {
+    return pathPart.slice(2);
+  }
+
+  return pathPart;
+}
+
+/**
+ * @param {string} eventPath
+ * @param {string[]} prefixes
+ * @returns {string[]}
+ */
+export function parseInternalFromEventPath(eventPath, prefixes) {
+  if (!eventPath) {
+    return [];
+  }
+
+  for (const prefix of prefixes) {
+    if (eventPath === prefix) {
+      return [];
+    }
+
+    if (eventPath.startsWith(`${prefix}/`)) {
+      return eventPath.slice(prefix.length + 1).split('/').filter(Boolean);
+    }
+  }
+
+  return [];
+}

--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -51,7 +51,7 @@ import { PROJECT_COMMERCE } from '@/utils/constants.js';
 import chats from '../api/chats';
 import SettingsWorkspace from './settings/SettingsWorkspace.vue';
 import SystemIntegrations from '../components/SystemIntegrations.vue';
-import { normalizeInternalPath } from '@/composables/useModuleUpdateRoute';
+import { normalizeInternalPath } from '@/utils/normalizeInternalPath';
 
 export default {
   name: 'SettingsView',


### PR DESCRIPTION
## Description

### Type of Change
* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [x] Tests
* [ ] Other

### Motivation and Context

The federated route sync logic in `useModuleUpdateRoute` contained integrations-specific hardcoding (`settingsChannels` → `integrations`) and a fixed list of default home paths (`init`, `apps/discovery`) to prevent deep links from being overwritten on mount. This made the composable harder to maintain and scale as new federated modules are added.

The remote Integrations module already receives the initial route via `getInitialModuleRoute()` when a deep link is present. The real issue was redundant `updateRoute` events emitted during mount sync, not missing host-side default path detection.

### Summary of Changes

- Extracted `normalizeInternalPath` and `parseInternalFromEventPath` to `src/utils/normalizeInternalPath.js`
- Added optional `updateRoutePathPrefixes` prop to `FederatedModule`, wired through `useFederatedModule` to `useModuleUpdateRoute`
- Configured Integrations explicitly with `:updateRoutePathPrefixes="['integrations']"` in `SystemIntegrations.vue`
- Removed `MODULE_DEFAULT_HOME_PATHS` and integrations-specific prefix hardcoding from `useModuleUpdateRoute`
- Moved deep link protection to the emitter in `useFederatedModule.setupRouterSync`, skipping redundant syncs until the module matches the host deep link
- Updated and added tests for configurable prefixes, emitter guard behavior, and Integrations prop wiring