### PR TITLE
🐛 Prevent Federated Modules From Redirecting Host After Navigation Away

### DIFF
--- a/src/composables/__tests__/useFederatedModule.spec.js
+++ b/src/composables/__tests__/useFederatedModule.spec.js
@@ -1,8 +1,9 @@
 import { defineComponent } from 'vue';
 import { mount, flushPromises } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ref } from 'vue';
+import { reactive, ref } from 'vue';
 import { useFederatedModule } from '../useFederatedModule';
+import { tryImportWithRetries } from '@/utils/moduleFederation';
 
 const { mockRouterAfterEach, mockRouterUnsubscribe, mockMountApp } = vi.hoisted(
   () => {
@@ -18,15 +19,21 @@ const { mockRouterAfterEach, mockRouterUnsubscribe, mockMountApp } = vi.hoisted(
   },
 );
 
-const routeRef = ref({
+const routeState = reactive({
   name: 'settingsChannels',
   params: { internal: ['init'] },
   query: {},
 });
 const modelValueRef = ref(true);
 
+function setRouteState({ name, params = {}, query = {} }) {
+  routeState.name = name;
+  routeState.params = params;
+  routeState.query = query;
+}
+
 vi.mock('vue-router', () => ({
-  useRoute: () => routeRef.value,
+  useRoute: () => routeState,
   useRouter: () => ({ replace: vi.fn() }),
 }));
 
@@ -48,6 +55,8 @@ vi.mock('@/store/Shared', () => ({
 
 function mountComposable(configOverrides = {}) {
   let afterEachCallback;
+  let fedApi;
+  const mockMountedAppUnmount = vi.fn();
 
   mockRouterAfterEach.mockImplementation((callback) => {
     afterEachCallback = callback;
@@ -55,7 +64,7 @@ function mountComposable(configOverrides = {}) {
   });
 
   mockMountApp.mockResolvedValue({
-    app: { unmount: vi.fn() },
+    app: { unmount: mockMountedAppUnmount },
     router: {
       afterEach: mockRouterAfterEach,
       replace: vi.fn(),
@@ -64,7 +73,7 @@ function mountComposable(configOverrides = {}) {
 
   const Wrapper = defineComponent({
     setup() {
-      useFederatedModule({
+      fedApi = useFederatedModule({
         moduleName: 'settingsChannels',
         importFn: () => Promise.resolve(mockMountApp),
         importPath: 'integrations/main',
@@ -82,7 +91,12 @@ function mountComposable(configOverrides = {}) {
 
   const wrapper = mount(Wrapper);
 
-  return { wrapper, getAfterEachCallback: () => afterEachCallback };
+  return {
+    wrapper,
+    getAfterEachCallback: () => afterEachCallback,
+    getFedApi: () => fedApi,
+    mockMountedAppUnmount,
+  };
 }
 
 describe('useFederatedModule setupRouterSync', () => {
@@ -93,11 +107,11 @@ describe('useFederatedModule setupRouterSync', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     modelValueRef.value = true;
-    routeRef.value = {
+    setRouteState({
       name: 'settingsChannels',
       params: { internal: ['init'] },
       query: {},
-    };
+    });
 
     dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
 
@@ -131,7 +145,7 @@ describe('useFederatedModule setupRouterSync', () => {
 
   it('skips default route sync while host deep link is not yet matched', async () => {
     wrapper.unmount();
-    routeRef.value.params.internal = ['apps', 'my'];
+    routeState.params.internal = ['apps', 'my'];
 
     ({ wrapper, getAfterEachCallback } = mountComposable());
     await flushPromises();
@@ -148,7 +162,7 @@ describe('useFederatedModule setupRouterSync', () => {
 
   it('stops skipping once module sync matches host deep link', async () => {
     wrapper.unmount();
-    routeRef.value.params.internal = ['apps', 'my'];
+    routeState.params.internal = ['apps', 'my'];
 
     ({ wrapper, getAfterEachCallback } = mountComposable());
     await flushPromises();
@@ -176,5 +190,82 @@ describe('useFederatedModule setupRouterSync', () => {
         },
       }),
     );
+  });
+});
+
+describe('useFederatedModule mount lifecycle', () => {
+  let wrapper;
+  let dispatchEventSpy;
+  let resolveImport;
+  let mockMountedAppUnmount;
+  let getFedApi;
+  let getAfterEachCallback;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    modelValueRef.value = true;
+    setRouteState({
+      name: 'settingsChannels',
+      params: { internal: ['init'] },
+      query: {},
+    });
+
+    dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+
+    vi.mocked(tryImportWithRetries).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveImport = () => resolve(mockMountApp);
+        }),
+    );
+  });
+
+  afterEach(() => {
+    vi.mocked(tryImportWithRetries).mockResolvedValue(mockMountApp);
+    dispatchEventSpy.mockRestore();
+    wrapper?.unmount();
+  });
+
+  it('aborts mount when user leaves module route before import completes', async () => {
+    const mounted = mountComposable({
+      activeModuleTracking: true,
+      inactivityTimeout: 5 * 60 * 1000,
+    });
+    wrapper = mounted.wrapper;
+    getFedApi = mounted.getFedApi;
+    mockMountedAppUnmount = mounted.mockMountedAppUnmount;
+
+    setRouteState({ name: 'settings', params: {}, query: {} });
+    modelValueRef.value = false;
+
+    resolveImport();
+    await flushPromises();
+
+    expect(getFedApi().app.value).toBe(null);
+    expect(mockMountApp).not.toHaveBeenCalled();
+    expect(mockMountedAppUnmount).not.toHaveBeenCalled();
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch updateRoute when host left module route', async () => {
+    vi.mocked(tryImportWithRetries).mockResolvedValue(mockMountApp);
+
+    const mounted = mountComposable();
+    wrapper = mounted.wrapper;
+    await flushPromises();
+
+    dispatchEventSpy.mockClear();
+
+    setRouteState({ name: 'settings', params: {}, query: {} });
+    modelValueRef.value = false;
+
+    const afterEachCallback = mounted.getAfterEachCallback();
+
+    afterEachCallback({
+      path: '/discovery',
+      query: {},
+    });
+
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/composables/__tests__/useModuleUpdateRoute.spec.js
+++ b/src/composables/__tests__/useModuleUpdateRoute.spec.js
@@ -126,4 +126,21 @@ describe('useModuleUpdateRoute', () => {
       query: { tab: '1' },
     });
   });
+
+  it('does not replace host route when shouldSyncHostRoute returns false', () => {
+    wrapper.unmount();
+
+    ({ wrapper } = mountComposable({
+      eventPathPrefixes: ['integrations'],
+      shouldSyncHostRoute: () => false,
+    }));
+
+    window.dispatchEvent(
+      new CustomEvent('updateRoute', {
+        detail: { path: 'settingsChannels/apps/my', query: {} },
+      }),
+    );
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
 });

--- a/src/composables/useFederatedModule.js
+++ b/src/composables/useFederatedModule.js
@@ -69,14 +69,28 @@ export function useFederatedModule(config) {
   const isMounting = ref(false);
   const unmountTimeoutId = ref(null);
   const skipInitialRouteSync = ref(false);
+  const mountGeneration = ref(0);
 
   const routeNameForSync = routeNameForUpdateRoute || moduleName;
   const syncPathPrefixes = [routeNameForSync, ...updateRoutePathPrefixes];
 
   const isModuleRoute = computed(() => routeNames.includes(route?.name));
 
+  function shouldSyncHostRoute() {
+    return routeNames.includes(route?.name) || unref(modelValue);
+  }
+
+  function isMountStale(generation) {
+    return generation !== mountGeneration.value;
+  }
+
+  function shouldKeepMounted(force) {
+    return force || (isModuleRoute.value && unref(modelValue));
+  }
+
   const { getInitialModuleRoute } = useModuleUpdateRoute(routeNameForSync, {
     eventPathPrefixes: updateRoutePathPrefixes,
+    shouldSyncHostRoute,
   });
 
   // --- Core Functions ---
@@ -122,6 +136,10 @@ export function useFederatedModule(config) {
     }
 
     routerUnsubscribe.value = moduleRouter.value.afterEach((to) => {
+      if (!isModuleRoute.value && !unref(modelValue)) {
+        return;
+      }
+
       const syncedInternal = getSyncedInternalPath(to.path);
       const hostInternal = normalizeInternalPath(route?.params?.internal);
 
@@ -166,9 +184,15 @@ export function useFederatedModule(config) {
       return;
     }
 
+    const generation = ++mountGeneration.value;
     isMounting.value = true;
 
     const mountApp = await tryImportWithRetries(importFn, importPath);
+
+    if (isMountStale(generation)) {
+      isMounting.value = false;
+      return;
+    }
 
     if (!mountApp) {
       if (iframeFallback) {
@@ -187,6 +211,12 @@ export function useFederatedModule(config) {
       containerId,
       initialRoute,
     });
+
+    if (isMountStale(generation) || !shouldKeepMounted(force)) {
+      mountedApp.unmount();
+      isMounting.value = false;
+      return;
+    }
 
     app.value = mountedApp;
     moduleRouter.value = mountedRouter;
@@ -288,20 +318,23 @@ export function useFederatedModule(config) {
         const isCurrentModuleRoute = routeNames.includes(newRoute);
 
         // Leaving the module route
-        if (
-          wasModuleRoute &&
-          !isCurrentModuleRoute &&
-          app.value &&
-          !useIframe.value
-        ) {
-          if (activeModuleTracking) {
-            sharedStore.setIsActiveFederatedModule(moduleName, false);
+        if (wasModuleRoute && !isCurrentModuleRoute) {
+          mountGeneration.value += 1;
+
+          if (isMounting.value) {
+            isMounting.value = false;
           }
 
-          if (inactivityTimeout !== null) {
-            unmountTimeoutId.value = setTimeout(() => {
-              unmount();
-            }, inactivityTimeout);
+          if (app.value && !useIframe.value) {
+            if (activeModuleTracking) {
+              sharedStore.setIsActiveFederatedModule(moduleName, false);
+            }
+
+            if (inactivityTimeout !== null) {
+              unmountTimeoutId.value = setTimeout(() => {
+                unmount();
+              }, inactivityTimeout);
+            }
           }
         }
 

--- a/src/composables/useModuleUpdateRoute.js
+++ b/src/composables/useModuleUpdateRoute.js
@@ -13,9 +13,13 @@ export { normalizeInternalPath, parseInternalFromEventPath };
  * @param {string} routeName - The name of the route to navigate to
  * @param {Object} [options]
  * @param {string[]} [options.eventPathPrefixes=[]] - Additional path prefixes accepted in updateRoute events
+ * @param {Function} [options.shouldSyncHostRoute] - When provided, host navigation runs only if this returns true
  * @returns {object} - Object containing getInitialModuleRoute function
  */
-export function useModuleUpdateRoute(routeName, { eventPathPrefixes = [] } = {}) {
+export function useModuleUpdateRoute(
+  routeName,
+  { eventPathPrefixes = [], shouldSyncHostRoute } = {},
+) {
   const router = useRouter();
   const route = useRoute();
   const acceptedPrefixes = [routeName, ...eventPathPrefixes];
@@ -37,6 +41,10 @@ export function useModuleUpdateRoute(routeName, { eventPathPrefixes = [] } = {})
     }
 
     if (!path.length) {
+      return;
+    }
+
+    if (shouldSyncHostRoute && !shouldSyncHostRoute()) {
       return;
     }
 


### PR DESCRIPTION
## Description

### Type of Change
* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Tests
* [ ] Other

### Motivation and Context

When opening a project, the host redirects to the default module (often insights) and starts loading the federated app asynchronously. If the user navigates to another page or module before loading finishes, the mount still completed in the background. When the remote router initialized, it emitted `updateRoute` events and the host listener called `router.replace`, forcing navigation back to insights even though the user was already elsewhere.

### Summary of Changes

- **`useFederatedModule`**
  - Added `mountGeneration` to invalidate in-flight mounts when the user leaves the module route or starts a new mount.
  - After each async step in `mount()`, abort if the generation is stale or the host is no longer on the module route (`shouldKeepMounted`).
  - Discard completed remote apps with `unmount()` when the user left before sync was set up.
  - Guard `setupRouterSync` `afterEach` so `updateRoute` is not dispatched when the host is off the module route and `modelValue` is false.
  - On route leave (active module tracking), increment `mountGeneration` and reset `isMounting` to cancel pending loads.

- **`useModuleUpdateRoute`**
  - Added optional `shouldSyncHostRoute` callback so `router.replace` runs only when the host is still viewing the federated module.

- **Tests**
  - Mount abort when leaving the module route before import completes.
  - No `updateRoute` dispatch from `afterEach` when the host left the module route.
  - `shouldSyncHostRoute: () => false` does not trigger host navigation.

Applies to all modules using `useFederatedModule` (insights, integrations, bulk send, etc.), not only insights.