### PR TITLE
fix: correct spelling of 'highlight' in Notifications.vue and QuickAccess.vue

### DIFF
--- a/src/components/common/RightBar/Notifications.vue
+++ b/src/components/common/RightBar/Notifications.vue
@@ -170,7 +170,7 @@ export default {
     font-size: $unnnic-font-size-body-gt;
     line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
 
-    :deep(.hightlight) {
+    :deep(.highlight) {
       color: $unnnic-color-weni-700;
       font-weight: $unnnic-font-weight-bold;
     }

--- a/src/views/ProjectHomeBlank/QuickAccess.vue
+++ b/src/views/ProjectHomeBlank/QuickAccess.vue
@@ -357,7 +357,7 @@ export default {
 
     border-radius: $unnnic-border-radius-sm;
 
-    :deep(.hightlight) {
+    :deep(.highlight) {
       color: $unnnic-color-brand-weni-soft;
     }
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Correct spelling
