### PR TITLE
feat: Migrate plural translations to ICU message format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [2.34.0] - 2026-06-16
+
+### Changed
+
+- feat: add ICU message compiler for vue-i18n using `intl-messageformat`
+- refactor: migrate pluralization strings from pipe syntax to ICU format in locale files (EN, ES, PT-BR, RO)
+
 ## [2.33.0] - 2026-06-12
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@growthbook/growthbook": "^1.4.1",
+        "@intlify/core-base": "^10.0.8",
         "@rspack/cli": "^1.1.5",
         "@rspack/core": "^1.1.5",
         "@sentry/browser": "^8.42.0",
@@ -24,6 +25,7 @@
         "emoji-js": "^3.8.0",
         "html-rspack-plugin": "^6.0.2",
         "iframessa": "^2.0.0",
+        "intl-messageformat": "^11.2.8",
         "javascript-time-ago": "^2.3.4",
         "keycloak-js": "^25.0.2",
         "libphonenumber-js": "^1.10.9",
@@ -2430,6 +2432,27 @@
       "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
       "license": "MIT"
     },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz",
+      "integrity": "sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.11.tgz",
+      "integrity": "sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.10"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.10.tgz",
+      "integrity": "sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==",
+      "license": "MIT"
+    },
     "node_modules/@growthbook/growthbook": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-1.6.4.tgz",
@@ -3216,6 +3239,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3255,6 +3279,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3275,6 +3300,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3295,6 +3321,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3315,6 +3342,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3335,6 +3363,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3355,6 +3384,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3375,6 +3405,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3395,6 +3426,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3415,6 +3447,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3435,6 +3468,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3455,6 +3489,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3475,6 +3510,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3495,6 +3531,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3512,6 +3549,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -6834,6 +6872,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -8573,6 +8612,16 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.8.tgz",
+      "integrity": "sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.6",
+        "@formatjs/icu-messageformat-parser": "3.5.11"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
@@ -10355,6 +10404,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@growthbook/growthbook": "^1.4.1",
+    "@intlify/core-base": "^10.0.8",
     "@rspack/cli": "^1.1.5",
     "@rspack/core": "^1.1.5",
     "@sentry/browser": "^8.42.0",
@@ -29,6 +30,7 @@
     "emoji-js": "^3.8.0",
     "html-rspack-plugin": "^6.0.2",
     "iframessa": "^2.0.0",
+    "intl-messageformat": "^11.2.8",
     "javascript-time-ago": "^2.3.4",
     "keycloak-js": "^25.0.2",
     "libphonenumber-js": "^1.10.9",

--- a/src/components/billing/WarningTrialChip.vue
+++ b/src/components/billing/WarningTrialChip.vue
@@ -19,13 +19,9 @@
       {{ $t('billing.modals.trial_expiring.short.title') }}
 
       {{
-        $t(
-          'billing.modals.trial_expiring.short.days',
-          {
-            days: daysTillTrialEnds,
-          },
-          daysTillTrialEnds,
-        )
+        $t('billing.modals.trial_expiring.short.days', {
+          count: daysTillTrialEnds,
+        })
       }}
     </template>
 

--- a/src/components/orgs/orgListItem.vue
+++ b/src/components/orgs/orgListItem.vue
@@ -7,7 +7,9 @@
     :options="options"
     :members="displayMembers"
     :membersDescription="
-      remainingMembers ? $t('orgs.remaining_members', remainingMembers) : null
+      remainingMembers
+        ? $t('orgs.remaining_members', { count: remainingMembers })
+        : null
     "
     @join="onSelectOrg"
   />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -107,7 +107,7 @@
     },
     "add_content": {
       "action_text": "Add content",
-      "n_contents_added": "{n} content file added|{n} content files added",
+      "n_contents_added": "{count, plural, one {{count} content file added} other {{count} content files added}}",
       "click_to_view_or_edit": "Click to view or edit"
     }
   },
@@ -700,7 +700,7 @@
     "removed_member": "Member removed",
     "removed_member_success": "{user} was removed from the organization. A notification email will be sent to them.",
     "save_success_text": "The name and description of your organization were changed. A notification email will be sent to members.",
-    "remaining_members": "+{n} member | +{n} members",
+    "remaining_members": "{count, plural, one {+{count} member} other {+{count} members}}",
     "delete_confirmation_title": "Organization deleted successfully",
     "delete_confirmation_text": "Organization {name} was deleted. A notification email will be sent to members.",
     "remove_member": "Remove member",
@@ -1455,7 +1455,7 @@
         "description": "The good news is that you have {days} days left in your trial. To continue using it,",
         "short": {
           "title": "Your trial period ends",
-          "days": "in {days} day|in {days} days"
+          "days": "{count, plural, one {in {count} day} other {in {count} days}}"
         }
       },
       "trial_expired": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -107,7 +107,7 @@
     },
     "add_content": {
       "action_text": "Añadir contenido",
-      "n_contents_added": "{n} contenido añadido|{n} contenidos añadidos",
+      "n_contents_added": "{count, plural, one {{count} contenido añadido} other {{count} contenidos añadidos}}",
       "click_to_view_or_edit": "Haga clic para ver o editar"
     }
   },
@@ -709,7 +709,7 @@
     "removed_member": "¡Miembro eliminado!",
     "removed_member_success": "El usuario de {user} ha sido eliminado de la organización y se le enviará un correo electrónico de aviso <emoji name=\"Winking Face\" />",
     "save_success_text": "El nombre/descripción de su organización ha sido modificado con éxito, se enviará un correo electrónico informativo a los miembros <emoji name=\"Winking Face\" />",
-    "remaining_members": "+{n} miembro | +{n} miembros",
+    "remaining_members": "{count, plural, one {+{count} miembro} other {+{count} miembros}}",
     "delete_confirmation_title": "¡Organización eliminada con éxito!",
     "delete_confirmation_text": "La organización {name} ha sido eliminada, se enviará un correo electrónico informativo a los miembros <emoji name=\"Winking Face\" />",
     "remove_member": "Eliminar miembro",
@@ -1465,7 +1465,7 @@
         "description": "La buena noticia es que todavía tienes {days} días con nosotros, pero ese no tiene que ser nuestro fin,",
         "short": {
           "title": "Su periodo de prueba finaliza",
-          "days": "en {days} día|en {days} días"
+          "days": "{count, plural, one {en {count} día} other {en {count} días}}"
         }
       },
       "trial_expired": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -107,7 +107,7 @@
     },
     "add_content": {
       "action_text": "Adicionar conteúdo",
-      "n_contents_added": "{n} conteúdo adicionado|{n} conteúdos adicionados",
+      "n_contents_added": "{count, plural, one {{count} conteúdo adicionado} other {{count} conteúdos adicionados}}",
       "click_to_view_or_edit": "Clique para visualizar ou editar"
     }
   },
@@ -709,7 +709,7 @@
     "removed_member": "Membro removido!",
     "removed_member_success": "O usuário de {user} foi retirado da organização e um e-mail de aviso será enviado <emoji name=\"Winking Face\" />",
     "save_success_text": "O nome/descrição da sua organização foi alterado com sucesso, um e-mail informativo será enviado aos membros <emoji name=\"Winking Face\" />",
-    "remaining_members": "+{n} membro | +{n} membros",
+    "remaining_members": "{count, plural, one {+{count} membro} other {+{count} membros}}",
     "delete_confirmation_title": "Organização excluída com sucesso!",
     "delete_confirmation_text": "A organização {name} foi excluída, um e-mail informativo será enviado aos membros <emoji name=\"Winking Face\" />",
     "remove_member": "Remover membro",
@@ -1465,7 +1465,7 @@
         "description": "A boa notícia é que você ainda tem {days} dias conosco, mas isso não precisa ser o nosso fim,",
         "short": {
           "title": "Seu período de teste acaba",
-          "days": "em {days} dia|em {days} dias"
+          "days": "{count, plural, one {em {count} dia} other {em {count} dias}}"
         }
       },
       "trial_expired": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -107,7 +107,7 @@
     },
     "add_content": {
       "action_text": "Adăugați conținut",
-      "n_contents_added": "{n} fișier de conținut adăugat|{n}  fișiere de conținut adăugate",
+      "n_contents_added": "{count, plural, one {{count} fișier de conținut adăugat} few {{count} fișiere de conținut adăugate} other {{count} de fișiere de conținut adăugate}}",
       "click_to_view_or_edit": "Apasă pentru a vizualiza sau edita"
     }
   },
@@ -700,7 +700,7 @@
     "removed_member": "Membru eliminat",
     "removed_member_success": "{user} a fost eliminat din organizație. Acesta va primi un e-mail de notificare.",
     "save_success_text": "Denumirea și descrierea organizației tale au fost schimbate. Un e-mail de notificare va fi trimis membrilor.",
-    "remaining_members": "+{n} membru | +{n} membri",
+    "remaining_members": "{count, plural, one {+{count} membru} few {+{count} membri} other {+{count} de membri}}",
     "delete_confirmation_title": "Organizația a fost ștearsă cu succes",
     "delete_confirmation_text": "Organizația {name} a fost ștearsă. Un e-mail de notificare va fi trimis membrilor.",
     "remove_member": "Elimină membru",
@@ -1455,7 +1455,7 @@
         "description": "Vestea bună este că mai ai {days} zile rămase din versiunea de încercare. Pentru a continua să o utilizezi,",
         "short": {
           "title": "Versiunea ta de încercare se încheie",
-          "days": "peste {days} zi|peste {days} zile"
+          "days": "{count, plural, one {peste {count} zi} few {peste {count} zile} other {peste {count} de zile}}"
         }
       },
       "trial_expired": {

--- a/src/utils/plugins/i18n.js
+++ b/src/utils/plugins/i18n.js
@@ -1,9 +1,11 @@
 import { createI18n } from 'vue-i18n';
+import { registerMessageCompiler } from '@intlify/core-base';
 
 import en from '@/locales/en.json';
 import es from '@/locales/es.json';
 import pt_br from '@/locales/pt_br.json';
 import ro from '@/locales/ro.json';
+import { icuMessageCompiler } from './icuMessageCompiler';
 
 const messages = {
   'pt-br': pt_br,
@@ -13,8 +15,18 @@ const messages = {
   ro,
 };
 
+/**
+ * The app runs vue-i18n in legacy mode, which drops the `messageCompiler`
+ * option (it is never forwarded to the core context). Registering the compiler
+ * globally is the supported way to make legacy mode use it, so the shared
+ * singleton renders ICU plural/select messages emitted by the migrated remotes
+ * and by weni-webapp's own migrated locales.
+ */
+registerMessageCompiler(icuMessageCompiler);
+
 export default createI18n({
   locale: 'en',
   fallbackLocale: 'en',
   messages,
+  messageCompiler: icuMessageCompiler,
 });

--- a/src/utils/plugins/icuMessageCompiler.js
+++ b/src/utils/plugins/icuMessageCompiler.js
@@ -1,0 +1,79 @@
+import IntlMessageFormat from 'intl-messageformat';
+import { compile as compileNative } from '@intlify/core-base';
+
+/**
+ * Matches real ICU blocks only: {var, plural|selectordinal, { … }
+ * or {var, select, { … }. Avoids false positives like
+ * "{user, select another option}" or "{item, plural forms available}".
+ */
+const ICU_PLURAL_OR_SELECTORDINAL_PATTERN =
+  /\{([a-zA-Z][\w]*),\s*(?:plural|selectordinal)\s*,\s*(?:(?:=\d+)|zero|one|two|few|many|other)\s*\{/i;
+
+const ICU_SELECT_PATTERN = /\{([a-zA-Z][\w]*),\s*select\s*,\s*[\w#.-]+\s*\{/i;
+
+/** Tag names in ICU XML markup (<b>, <i>, <br>) need function handlers in .format(). */
+const ICU_XML_TAG_PATTERN = /<\/?([a-zA-Z][a-zA-Z0-9]*)\b/g;
+
+export function shouldUseIntlMessageFormat(message) {
+  return (
+    ICU_PLURAL_OR_SELECTORDINAL_PATTERN.test(message) ||
+    ICU_SELECT_PATTERN.test(message)
+  );
+}
+
+function createDefaultTagHandler(tagName) {
+  if (tagName === 'br') {
+    return (chunks) => chunks.join('') + ' ';
+  }
+
+  return (chunks) => {
+    const content = chunks.join('');
+    return `<${tagName}>${content}</${tagName}>`;
+  };
+}
+
+/**
+ * Merges $t params with default ICU tag handlers so plural + HTML works without
+ * passing b/i/br manually on every call.
+ */
+function buildIntlFormatValues(message, values = {}) {
+  const formatValues = { ...(values || {}) };
+  let match;
+
+  while ((match = ICU_XML_TAG_PATTERN.exec(message)) !== null) {
+    const tagName = match[1];
+    const existing = formatValues[tagName];
+
+    if (typeof existing === 'function') {
+      continue;
+    }
+
+    formatValues[tagName] = createDefaultTagHandler(tagName);
+  }
+
+  ICU_XML_TAG_PATTERN.lastIndex = 0;
+  return formatValues;
+}
+
+/**
+ * Vue I18n custom messageCompiler.
+ * ICU plural/select messages are rendered through IntlMessageFormat so the host
+ * can display the ICU pattern emitted by migrated remotes and the own migrated locales.
+ * Every other message (plain `{var}` interpolation, linked messages, HTML, and
+ * the not-yet-migrated insights remote) is delegated to vue-i18n's native
+ * compiler so existing behavior is preserved.
+ */
+export const icuMessageCompiler = (message, context) => {
+  if (typeof message === 'string' && shouldUseIntlMessageFormat(message)) {
+    const formatter = new IntlMessageFormat(message, context.locale);
+    return (ctx) => {
+      const formatted = formatter.format(
+        buildIntlFormatValues(message, ctx.values),
+      );
+      const parts = Array.isArray(formatted) ? formatted : [formatted];
+      return ctx.normalize(parts);
+    };
+  }
+
+  return compileNative(message, context);
+};

--- a/src/views/register/forms/TemplateGallery.vue
+++ b/src/views/register/forms/TemplateGallery.vue
@@ -248,10 +248,9 @@
             @click.prevent="showModalAddContent = true"
           >
             {{
-              $t(
-                'custom_agent.add_content.n_contents_added',
-                amountContentsAdded,
-              )
+              $t('custom_agent.add_content.n_contents_added', {
+                count: amountContentsAdded,
+              })
             }}
 
             <a>


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Vue I18n's legacy mode does not support ICU message format natively, which is required to handle plural and select messages emitted by migrated remotes and the app's own locale files. A custom message compiler is needed to bridge ICU syntax with vue-i18n's existing behavior.

### Summary of Changes
- Added `intl-messageformat` and `@intlify/core-base` as dependencies to handle ICU plural and select message formatting.
- Introduced `icuMessageCompiler.js`, a custom vue-i18n message compiler that routes ICU plural/select messages through `IntlMessageFormat` while delegating all other messages (plain interpolation, linked messages, HTML) to vue-i18n's native compiler.
- Registered the ICU message compiler globally via `registerMessageCompiler` in `i18n.js` to ensure it works in legacy mode, and also passed it as the `messageCompiler` option.
- Migrated plural translation strings in `en.json`, `es.json`, `pt_br.json`, and `ro.json` from vue-i18n's pipe-separated plural syntax (`{n} item | {n} items`) to ICU plural syntax (`{count, plural, one {...} other {...}}`), including proper `few` and `other` plural categories for Romanian.
- Updated call sites in `WarningTrialChip.vue`, `orgListItem.vue`, and `TemplateGallery.vue` to pass `{ count: value }` instead of a bare numeric argument for plural resolution.