### PR TITLE
refactor: remove unused chats configuration and related methods in settings.vue

### DIFF
--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -48,7 +48,6 @@ import { mapGetters } from 'vuex';
 import getEnv from '@/utils/env';
 import { PROJECT_ROLE_CHATUSER } from '../components/users/permissionsObjects';
 import { PROJECT_COMMERCE } from '@/utils/constants.js';
-import chats from '../api/chats';
 import SettingsWorkspace from './settings/SettingsWorkspace.vue';
 import SystemIntegrations from '../components/SystemIntegrations.vue';
 import { normalizeInternalPath } from '@/utils/normalizeInternalPath';
@@ -65,7 +64,6 @@ export default {
     return {
       initialLoaded: false,
       showOverlay: false,
-      chatsConfig: null,
     };
   },
 
@@ -109,10 +107,7 @@ export default {
     pages() {
       const options = [];
 
-      if (
-        getEnv('MODULES_YAML').chats &&
-        (!this.enableGroups || this.isPrimaryProject)
-      ) {
+      if (getEnv('MODULES_YAML').chats) {
         options.push({
           key: 'chatsConfig',
           label: this.$t('settings.chats.title'),
@@ -168,15 +163,6 @@ export default {
         () => import('../components/ExternalSystem.vue'),
       );
     },
-    isPrimaryProject() {
-      return !!this.chatsConfig?.config?.its_principal;
-    },
-    isSecondaryProject() {
-      return this.chatsConfig?.config?.its_principal === false;
-    },
-    enableGroups() {
-      return this.isPrimaryProject || this.isSecondaryProject;
-    },
   },
 
   watch: {
@@ -219,10 +205,6 @@ export default {
         this.$router.push({ name: targetRoute });
       },
     },
-  },
-
-  async created() {
-    this.chatsConfig = await chats.getProjectInfo(this.currentProject?.uuid);
   },
 
   mounted() {
@@ -309,11 +291,11 @@ export default {
 
   :deep(.unnnic-sidebar-items) {
     position: relative;
-    margin-right: -$unnnic-spacing-sm;
+    margin-right: -$unnnic-space-4;
   }
 
   :deep(.unnnic-sidebar-item) {
-    margin-right: $unnnic-spacing-sm;
+    margin-right: $unnnic-space-4;
 
     > * {
       color: $unnnic-color-fg-base;
@@ -333,13 +315,13 @@ export default {
   }
 
   :deep(.unnnic-sidebar-item-child) {
-    margin-right: $unnnic-spacing-sm;
+    margin-right: $unnnic-space-4;
   }
 
   .options {
     width: 200px;
     height: fit-content;
-    padding: $unnnic-spacing-sm;
+    padding: $unnnic-space-4;
   }
 
   .separator {


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The chats configuration page visibility was previously gated behind a check for primary/secondary project status, which required an additional API call on component creation. This logic has been simplified to remove the unnecessary dependency.

### Summary of Changes
- Removed the `chats` API import and the `getProjectInfo` call that was previously made on component creation
- Removed `chatsConfig` data property along with the `isPrimaryProject`, `isSecondaryProject`, and `enableGroups` computed properties
- Simplified the chats page visibility condition to only check if the `chats` module is enabled in `MODULES_YAML`, removing the group-based restrictions
- Updated spacing tokens from `$unnnic-spacing-sm` to `$unnnic-space-4` in sidebar and options styles