### PR TITLE
feat: implement SSO configuration management in organization settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [2.35.0] - 2026-06-18
+
+### Added
+
+- feat: implement SSO configuration management in organization settings
+
+### Fixed
+
+- LOC-25665 - Weni's Webapp portuguese fix
+
 ## [2.34.0] - 2026-06-16
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "cross-env NODE_ENV=development rspack dev --port 3002",
+    "dev": "cross-env NODE_ENV=development rspack dev",
     "build": "cross-env NODE_ENV=production rspack build",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/src/api/orgs.js
+++ b/src/api/orgs.js
@@ -67,6 +67,27 @@ export default {
     return request.$http().delete(`/v1/organization/org/${uuid}/`);
   },
 
+  getSSOConfig({ organizationUuid }) {
+    return request
+      .$http()
+      .get(`/v1/organization/org/${organizationUuid}/sso-settings/`);
+  },
+
+  updateSSOConfig({
+    organizationUuid,
+    isEnabled,
+    allowedEmailDomains,
+    allowedSSOProviders,
+  }) {
+    return request
+      .$http()
+      .patch(`/v1/organization/org/${organizationUuid}/sso-settings/`, {
+        is_enabled: isEnabled,
+        allowed_email_domains: allowedEmailDomains,
+        allowed_sso_providers: allowedSSOProviders,
+      });
+  },
+
   billingPricing() {
     return request.$http().get('/v1/organization/org/billing/precification/');
   },

--- a/src/components/common/RightBar/Index.vue
+++ b/src/components/common/RightBar/Index.vue
@@ -19,12 +19,18 @@
     >
       <template v-if="type === 'OrgSettings'">
         <div class="settings-header">
-          <UnnnicIcon
-            icon="keyboard_backspace"
-            scheme="neutral-darkest"
-            clickable
-            @click="close"
-          ></UnnnicIcon>
+          <div class="settings-header__title-row">
+            <h1 class="settings-header__title">
+              {{ $t('orgs.settings_title') }}
+            </h1>
+
+            <UnnnicIcon
+              icon="close"
+              scheme="neutral-darkest"
+              clickable
+              @click="close"
+            />
+          </div>
 
           <UnnnicTab
             :activeTab="activeTab"
@@ -287,13 +293,29 @@ export default {
 <style lang="scss" scoped>
 .settings-header {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+
+  &__title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    column-gap: $unnnic-spacing-sm;
+    margin-bottom: $unnnic-spacing-md;
+  }
+
+  &__title {
+    margin: 0;
+    color: $unnnic-color-neutral-darkest;
+    font-family: $unnnic-font-family-secondary;
+    font-weight: $unnnic-font-weight-bold;
+    font-size: $unnnic-font-size-title-sm;
+    line-height: $unnnic-font-size-title-sm + $unnnic-line-height-md;
+  }
 
   .tab {
     width: 100%;
 
     :deep(.tab-header) {
-      margin-left: $unnnic-spacing-inline-md;
       margin-bottom: 0;
     }
   }

--- a/src/components/common/RightBar/updateOrg.vue
+++ b/src/components/common/RightBar/updateOrg.vue
@@ -48,94 +48,97 @@
     </template>
 
     <template #tab-panel-second>
-      <div class="weni-update-org__security">
-        <h2 class="weni-update-org__title">
-          {{ $t('orgs.2fa_title') }}
-          <UnnnicTag
-            scheme="aux-baby-blue"
-            :text="$t('orgs.recommended')"
-            type="default"
-          />
-        </h2>
-        <p class="weni-update-org__description">
-          {{ $t('orgs.2fa_description') }}
-        </p>
-
-        <UnnnicSwitch
-          v-model="enable2FA"
-          :textRight="$t('orgs.enable_2fa')"
-        />
-
-        <div class="separator" />
-
-        <h2 class="weni-update-org__title">
-          {{ $t('orgs.sso.title') }}
-        </h2>
-        <p class="weni-update-org__description">
-          {{ $t('orgs.sso.description') }}
-        </p>
-
-        <div class="weni-update-org__sso-switch">
-          <UnnnicSwitch
-            v-model="ssoForm.isEnabled"
-            :textRight="$t('orgs.sso.enable')"
-          />
-          <p class="weni-update-org__sso-helper">
-            {{ $t('orgs.sso.helper') }}
+      <div class="weni-update-org__panel">
+        <div class="weni-update-org__security">
+          <h2 class="weni-update-org__title">
+            {{ $t('orgs.2fa_title') }}
+            <UnnnicTag
+              scheme="aux-baby-blue"
+              :text="$t('orgs.recommended')"
+              type="default"
+            />
+          </h2>
+          <p class="weni-update-org__description">
+            {{ $t('orgs.2fa_description') }}
           </p>
+
+          <UnnnicSwitch
+            v-model="enable2FA"
+            :textRight="$t('orgs.enable_2fa')"
+          />
+
+          <div class="separator" />
+
+          <h2 class="weni-update-org__title">
+            {{ $t('orgs.sso.title') }}
+          </h2>
+          <p class="weni-update-org__description">
+            {{ $t('orgs.sso.description') }}
+          </p>
+
+          <div class="weni-update-org__sso-switch">
+            <UnnnicSwitch
+              v-model="ssoForm.isEnabled"
+              :textRight="$t('orgs.sso.enable')"
+            />
+            <p class="weni-update-org__sso-helper">
+              {{ $t('orgs.sso.helper') }}
+            </p>
+          </div>
+
+          <template v-if="ssoForm.isEnabled">
+            <UnnnicFormElement
+              class="weni-update-org__sso-field"
+              :label="$t('orgs.sso.provider_label')"
+            >
+              <UnnnicSelect
+                :modelValue="ssoForm.provider ?? ''"
+                :options="providerOptions"
+                :placeholder="$t('orgs.sso.provider_placeholder')"
+                @update:model-value="ssoForm.provider = $event || null"
+              />
+            </UnnnicFormElement>
+
+            <UnnnicInput
+              v-model="ssoForm.domainInput"
+              class="weni-update-org__sso-field"
+              :label="$t('orgs.sso.allowed_domains')"
+              :placeholder="$t('orgs.sso.allowed_domains_placeholder')"
+              @keydown.enter="addDomain"
+            />
+
+            <div
+              v-if="ssoForm.domains.length"
+              class="weni-update-org__sso-domains"
+            >
+              <UnnnicChip
+                v-for="domain in ssoForm.domains"
+                :key="domain"
+                type="multiple"
+                :isSelected="true"
+                :text="domain"
+                @click="removeDomain(domain)"
+              />
+            </div>
+          </template>
         </div>
 
-        <template v-if="ssoForm.isEnabled">
-          <UnnnicFormElement
-            class="weni-update-org__sso-field"
-            :label="$t('orgs.sso.provider_label')"
+        <div class="weni-update-org__footer">
+          <UnnnicButton
+            type="tertiary"
+            @click="$emit('close')"
           >
-            <UnnnicSelectSmart
-              :modelValue="selectedProviderValue"
-              :options="providerOptions"
-              @update:model-value="ssoForm.provider = $event[0].value || null"
-            />
-          </UnnnicFormElement>
-
-          <UnnnicInput
-            v-model="ssoForm.domainInput"
-            class="weni-update-org__sso-field"
-            :label="$t('orgs.sso.allowed_domains')"
-            :placeholder="$t('orgs.sso.allowed_domains_placeholder')"
-            @keydown.enter="addDomain"
-          />
-
-          <div
-            v-if="ssoForm.domains.length"
-            class="weni-update-org__sso-domains"
+            {{ $t('cancel') }}
+          </UnnnicButton>
+          <UnnnicButton
+            type="primary"
+            :loading="loadingSSO || loading2FA"
+            :disabled="isSaveDisabled"
+            @click="saveChanges"
           >
-            <UnnnicChip
-              v-for="domain in ssoForm.domains"
-              :key="domain"
-              type="multiple"
-              :isSelected="true"
-              :text="domain"
-              @click="removeDomain(domain)"
-            />
-          </div>
-        </template>
-      </div>
-
-      <div class="weni-update-org__footer">
-        <UnnnicButton
-          type="tertiary"
-          @click="$emit('close')"
-        >
-          {{ $t('cancel') }}
-        </UnnnicButton>
-        <UnnnicButton
-          type="primary"
-          :loading="loadingSSO || loading2FA"
-          :disabled="isSaveDisabled"
-          @click="saveChanges"
-        >
-          {{ $t('orgs.save') }}
-        </UnnnicButton>
+            {{ $t('orgs.save') }}
+          </UnnnicButton>
+        </div>
       </div>
     </template>
   </UnnnicTab>
@@ -183,6 +186,12 @@ export default {
         domainInput: '',
       },
 
+      ssoBaseline: {
+        isEnabled: false,
+        provider: null,
+        domains: [],
+      },
+
       tabs: ['first', 'second'],
       loading2FA: false,
       loadingSSO: false,
@@ -210,40 +219,10 @@ export default {
     },
 
     providerOptions() {
-      return [
-        { value: '', label: this.$t('orgs.sso.provider_placeholder') },
-        ...SSO_PROVIDERS.map((provider) => ({
-          value: provider,
-          label: provider.charAt(0).toUpperCase() + provider.slice(1),
-        })),
-      ];
-    },
-
-    selectedProviderValue() {
-      const selected = this.providerOptions.find(
-        ({ value }) => value === (this.ssoForm.provider || ''),
-      );
-
-      return selected ? [selected] : [this.providerOptions[0]];
-    },
-
-    ssoFormAsConfig() {
-      return {
-        is_enabled: this.ssoForm.isEnabled,
-        allowed_email_domains: this.ssoForm.domains,
-        allowed_sso_providers: this.ssoForm.provider
-          ? [this.ssoForm.provider]
-          : [],
-      };
-    },
-
-    orgSSOConfig() {
-      return {
-        is_enabled: false,
-        allowed_email_domains: [],
-        allowed_sso_providers: [],
-        ...this.org.sso_config,
-      };
+      return SSO_PROVIDERS.map((provider) => ({
+        value: provider,
+        label: provider.charAt(0).toUpperCase() + provider.slice(1),
+      }));
     },
 
     twoFADirty() {
@@ -251,7 +230,10 @@ export default {
     },
 
     ssoDirty() {
-      return !_.isEqual(this.ssoFormAsConfig, this.orgSSOConfig);
+      return !_.isEqual(
+        this._ssoComparableState(this.ssoForm),
+        this.ssoBaseline,
+      );
     },
 
     ssoValid() {
@@ -276,12 +258,8 @@ export default {
     this.formData = { name, description };
     this.enable2FA = this.org.enforce_2fa;
 
-    this.ssoForm = {
-      isEnabled: this.orgSSOConfig.is_enabled,
-      provider: this.orgSSOConfig.allowed_sso_providers[0] ?? null,
-      domains: [...this.orgSSOConfig.allowed_email_domains],
-      domainInput: '',
-    };
+    this.ssoForm = this._hydrateSsoFromOrg(this.org);
+    this.ssoBaseline = this._ssoComparableState(this.ssoForm);
   },
   methods: {
     ...mapActions([
@@ -418,19 +396,35 @@ export default {
       }
     },
 
+    _hydrateSsoFromOrg(org) {
+      const config = org.sso_config ?? {};
+
+      return {
+        isEnabled: config.is_enabled ?? false,
+        provider: config.allowed_sso_providers?.[0] ?? null,
+        domains: [...(config.allowed_email_domains ?? [])],
+        domainInput: '',
+      };
+    },
+
+    _ssoComparableState({ isEnabled, provider, domains }) {
+      return { isEnabled, provider, domains };
+    },
+
     async updateSSOConfig() {
       try {
         this.loadingSSO = true;
 
-        const config = this.ssoFormAsConfig;
+        const { isEnabled, provider, domains } = this.ssoForm;
         const response = await orgs.updateSSOConfig({
           organizationUuid: this.orgUuid,
-          isEnabled: config.is_enabled,
-          allowedEmailDomains: config.allowed_email_domains,
-          allowedSSOProviders: config.allowed_sso_providers,
+          isEnabled,
+          allowedEmailDomains: domains,
+          allowedSSOProviders: provider ? [provider] : [],
         });
 
         this.org.sso_config = response.data;
+        this.ssoBaseline = this._ssoComparableState(this.ssoForm);
 
         this.showSuccessToast();
 
@@ -562,10 +556,32 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.settings-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+
+  :deep(.tab-body),
+  :deep(.tab-panel) {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+}
+
 .tab {
   :deep(.tab-header) {
     display: none;
   }
+}
+
+.weni-update-org__panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .separator {
@@ -665,7 +681,7 @@ export default {
   display: flex;
   justify-content: flex-end;
   column-gap: $unnnic-spacing-inline-sm;
-  margin-top: $unnnic-spacing-stack-lg;
+  margin-top: auto;
   padding-top: $unnnic-spacing-stack-md;
   border-top: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
 }

--- a/src/components/common/RightBar/updateOrg.vue
+++ b/src/components/common/RightBar/updateOrg.vue
@@ -48,32 +48,95 @@
     </template>
 
     <template #tab-panel-second>
-      <h2 class="weni-update-org__title">
-        {{ $t('orgs.2fa_title') }}
-        <UnnnicTag
-          scheme="aux-baby-blue"
-          :text="$t('orgs.recommended')"
-          type="default"
+      <div class="weni-update-org__security">
+        <h2 class="weni-update-org__title">
+          {{ $t('orgs.2fa_title') }}
+          <UnnnicTag
+            scheme="aux-baby-blue"
+            :text="$t('orgs.recommended')"
+            type="default"
+          />
+        </h2>
+        <p class="weni-update-org__description">
+          {{ $t('orgs.2fa_description') }}
+        </p>
+
+        <UnnnicSwitch
+          v-model="enable2FA"
+          :textRight="$t('orgs.enable_2fa')"
         />
-      </h2>
-      <p class="weni-update-org__description">
-        {{ $t('orgs.2fa_description') }}
-      </p>
 
-      <UnnnicSwitch
-        v-model="enable2FA"
-        :textRight="$t('orgs.enable_2fa')"
-      />
+        <div class="separator" />
 
-      <UnnnicButton
-        type="secondary"
-        class="weni-update-org__button"
-        :loading="loading2FA"
-        :disabled="enable2FA === org.enforce_2fa"
-        @click="beforeUpdate2FAVerification"
-      >
-        {{ $t('orgs.save') }}
-      </UnnnicButton>
+        <h2 class="weni-update-org__title">
+          {{ $t('orgs.sso.title') }}
+        </h2>
+        <p class="weni-update-org__description">
+          {{ $t('orgs.sso.description') }}
+        </p>
+
+        <div class="weni-update-org__sso-switch">
+          <UnnnicSwitch
+            v-model="ssoForm.isEnabled"
+            :textRight="$t('orgs.sso.enable')"
+          />
+          <p class="weni-update-org__sso-helper">
+            {{ $t('orgs.sso.helper') }}
+          </p>
+        </div>
+
+        <template v-if="ssoForm.isEnabled">
+          <UnnnicFormElement
+            class="weni-update-org__sso-field"
+            :label="$t('orgs.sso.provider_label')"
+          >
+            <UnnnicSelectSmart
+              :modelValue="selectedProviderValue"
+              :options="providerOptions"
+              @update:model-value="ssoForm.provider = $event[0].value || null"
+            />
+          </UnnnicFormElement>
+
+          <UnnnicInput
+            v-model="ssoForm.domainInput"
+            class="weni-update-org__sso-field"
+            :label="$t('orgs.sso.allowed_domains')"
+            :placeholder="$t('orgs.sso.allowed_domains_placeholder')"
+            @keydown.enter="addDomain"
+          />
+
+          <div
+            v-if="ssoForm.domains.length"
+            class="weni-update-org__sso-domains"
+          >
+            <UnnnicChip
+              v-for="domain in ssoForm.domains"
+              :key="domain"
+              type="multiple"
+              :isSelected="true"
+              :text="domain"
+              @click="removeDomain(domain)"
+            />
+          </div>
+        </template>
+      </div>
+
+      <div class="weni-update-org__footer">
+        <UnnnicButton
+          type="tertiary"
+          @click="$emit('close')"
+        >
+          {{ $t('cancel') }}
+        </UnnnicButton>
+        <UnnnicButton
+          type="primary"
+          :loading="loadingSSO || loading2FA"
+          :disabled="isSaveDisabled"
+          @click="saveChanges"
+        >
+          {{ $t('orgs.save') }}
+        </UnnnicButton>
+      </div>
     </template>
   </UnnnicTab>
 </template>
@@ -81,8 +144,12 @@
 <script>
 import { mapActions } from 'vuex';
 import account from '../../../api/account';
+import orgs from '../../../api/orgs';
 import { openAlertModal } from '../../../utils/openServerErrorAlertModal';
+import Unnnic from '@weni/unnnic-system';
 import _ from 'lodash';
+
+const SSO_PROVIDERS = ['google', 'microsoft'];
 
 export default {
   name: 'UpdateOrg',
@@ -97,6 +164,9 @@ export default {
       type: String,
     },
   },
+
+  emits: ['remove-org', 'close'],
+
   data() {
     return {
       formData: {
@@ -106,8 +176,16 @@ export default {
 
       enable2FA: null,
 
+      ssoForm: {
+        isEnabled: false,
+        provider: null,
+        domains: [],
+        domainInput: '',
+      },
+
       tabs: ['first', 'second'],
       loading2FA: false,
+      loadingSSO: false,
 
       loading: false,
     };
@@ -130,6 +208,66 @@ export default {
         this.formData.description === this.org.description
       );
     },
+
+    providerOptions() {
+      return [
+        { value: '', label: this.$t('orgs.sso.provider_placeholder') },
+        ...SSO_PROVIDERS.map((provider) => ({
+          value: provider,
+          label: provider.charAt(0).toUpperCase() + provider.slice(1),
+        })),
+      ];
+    },
+
+    selectedProviderValue() {
+      const selected = this.providerOptions.find(
+        ({ value }) => value === (this.ssoForm.provider || ''),
+      );
+
+      return selected ? [selected] : [this.providerOptions[0]];
+    },
+
+    ssoFormAsConfig() {
+      return {
+        is_enabled: this.ssoForm.isEnabled,
+        allowed_email_domains: this.ssoForm.domains,
+        allowed_sso_providers: this.ssoForm.provider
+          ? [this.ssoForm.provider]
+          : [],
+      };
+    },
+
+    orgSSOConfig() {
+      return {
+        is_enabled: false,
+        allowed_email_domains: [],
+        allowed_sso_providers: [],
+        ...this.org.sso_config,
+      };
+    },
+
+    twoFADirty() {
+      return this.enable2FA !== this.org.enforce_2fa;
+    },
+
+    ssoDirty() {
+      return !_.isEqual(this.ssoFormAsConfig, this.orgSSOConfig);
+    },
+
+    ssoValid() {
+      return (
+        !this.ssoForm.isEnabled ||
+        (!!this.ssoForm.provider && this.ssoForm.domains.length > 0)
+      );
+    },
+
+    isSaveDisabled() {
+      if (this.ssoDirty && !this.ssoValid) {
+        return true;
+      }
+
+      return !(this.twoFADirty || this.ssoDirty);
+    },
   },
 
   mounted() {
@@ -137,6 +275,13 @@ export default {
 
     this.formData = { name, description };
     this.enable2FA = this.org.enforce_2fa;
+
+    this.ssoForm = {
+      isEnabled: this.orgSSOConfig.is_enabled,
+      provider: this.orgSSOConfig.allowed_sso_providers[0] ?? null,
+      domains: [...this.orgSSOConfig.allowed_email_domains],
+      domainInput: '',
+    };
   },
   methods: {
     ...mapActions([
@@ -240,6 +385,96 @@ export default {
       } finally {
         this.loading2FA = false;
       }
+    },
+
+    addDomain() {
+      const domain = this.ssoForm.domainInput
+        .trim()
+        .replace(/^@/, '')
+        .toLowerCase();
+
+      if (domain && !this.ssoForm.domains.includes(domain)) {
+        this.ssoForm.domains.push(domain);
+      }
+
+      this.ssoForm.domainInput = '';
+    },
+
+    removeDomain(domain) {
+      this.ssoForm.domains = this.ssoForm.domains.filter((d) => d !== domain);
+    },
+
+    async saveChanges() {
+      if (this.ssoDirty) {
+        const saved = await this.updateSSOConfig();
+
+        if (!saved) {
+          return;
+        }
+      }
+
+      if (this.twoFADirty) {
+        this.beforeUpdate2FAVerification();
+      }
+    },
+
+    async updateSSOConfig() {
+      try {
+        this.loadingSSO = true;
+
+        const config = this.ssoFormAsConfig;
+        const response = await orgs.updateSSOConfig({
+          organizationUuid: this.orgUuid,
+          isEnabled: config.is_enabled,
+          allowedEmailDomains: config.allowed_email_domains,
+          allowedSSOProviders: config.allowed_sso_providers,
+        });
+
+        this.org.sso_config = response.data;
+
+        this.showSuccessToast();
+
+        return true;
+      } catch (error) {
+        this.showSSOErrorToast(error);
+
+        return false;
+      } finally {
+        this.loadingSSO = false;
+      }
+    },
+
+    showSuccessToast() {
+      Unnnic.unnnicCallAlert({
+        props: {
+          title: this.$t('orgs.save_success'),
+          icon: 'check_circle',
+          scheme: 'feedback-green',
+          position: 'bottom-right',
+          closeText: this.$t('close'),
+        },
+        seconds: 3,
+      });
+    },
+
+    showSSOErrorToast(error) {
+      const isLockout = error?.response?.status === 400;
+
+      Unnnic.unnnicCallAlert({
+        props: {
+          title: isLockout
+            ? this.$t('orgs.sso.lockout_error.title')
+            : this.$t('orgs.error'),
+          text: isLockout
+            ? this.$t('orgs.sso.lockout_error.description')
+            : error?.response?.data?.detail || this.$t('orgs.save_error'),
+          icon: 'error',
+          scheme: 'feedback-red',
+          position: 'bottom-right',
+          closeText: this.$t('close'),
+        },
+        seconds: 5,
+      });
     },
 
     showEnabledConfirmation() {
@@ -392,7 +627,46 @@ export default {
   color: $unnnic-color-neutral-cloudy;
 }
 
-.unnnic-switch {
-  margin: $unnnic-spacing-stack-md 0 $unnnic-spacing-stack-xl;
+.weni-update-org__security {
+  .unnnic-switch {
+    margin-top: $unnnic-spacing-stack-md;
+  }
+}
+
+.weni-update-org__sso-switch {
+  margin-top: $unnnic-spacing-stack-md;
+
+  .unnnic-switch {
+    margin-top: 0;
+  }
+}
+
+.weni-update-org__sso-helper {
+  font-size: $unnnic-font-size-body-md;
+  font-weight: $unnnic-font-weight-regular;
+  line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+  margin: $unnnic-spacing-stack-nano 0 0;
+  padding-left: $unnnic-spacing-inline-md + $unnnic-spacing-inline-sm;
+  color: $unnnic-color-neutral-cloudy;
+}
+
+.weni-update-org__sso-field {
+  margin-top: $unnnic-spacing-stack-sm;
+}
+
+.weni-update-org__sso-domains {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $unnnic-spacing-stack-xs;
+  margin-top: $unnnic-spacing-stack-sm;
+}
+
+.weni-update-org__footer {
+  display: flex;
+  justify-content: flex-end;
+  column-gap: $unnnic-spacing-inline-sm;
+  margin-top: $unnnic-spacing-stack-lg;
+  padding-top: $unnnic-spacing-stack-md;
+  border-top: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
 }
 </style>

--- a/src/components/orgs/OrgCard.vue
+++ b/src/components/orgs/OrgCard.vue
@@ -1,10 +1,27 @@
 <template>
   <div
     class="org-card"
-    @click="role === ORG_ROLE_FINANCIAL ? $emit('billing') : $emit('enter')"
+    :class="{ 'org-card--disabled': isAccessDisabled }"
+    @click="onCardClick"
   >
-    <div>
-      <h2 class="name">{{ name }}</h2>
+    <div class="org-card__content">
+      <div class="name-row">
+        <h2 class="name">{{ name }}</h2>
+
+        <UnnnicToolTip
+          v-if="isAccessDisabled"
+          :text="disabledTooltipText"
+          enabled
+          maxWidth="18.125rem"
+          side="top"
+        >
+          <UnnnicIconSvg
+            size="md"
+            icon="info"
+            scheme="feedback-red"
+          />
+        </UnnnicToolTip>
+      </div>
 
       <p class="description">
         {{ description }}
@@ -17,7 +34,11 @@
       />
     </div>
 
-    <div>
+    <div
+      v-if="showOptionsMenu"
+      class="org-card__options"
+      @click.stop
+    >
       <UnnnicDropdown
         :open="isOptionsOpen"
         class="unnnic-dropdown"
@@ -33,7 +54,7 @@
         </template>
 
         <div
-          v-if="role === ORG_ROLE_CONTRIBUTOR"
+          v-if="!isAccessDisabled && role === ORG_ROLE_CONTRIBUTOR"
           class="option"
           @click="$emit('view')"
         >
@@ -47,7 +68,7 @@
         </div>
 
         <div
-          v-if="role === ORG_ROLE_ADMIN"
+          v-if="!isAccessDisabled && role === ORG_ROLE_ADMIN"
           class="option"
           @click="$emit('manage')"
         >
@@ -61,7 +82,10 @@
         </div>
 
         <div
-          v-if="[ORG_ROLE_FINANCIAL, ORG_ROLE_ADMIN].includes(role)"
+          v-if="
+            !isAccessDisabled &&
+            [ORG_ROLE_FINANCIAL, ORG_ROLE_ADMIN].includes(role)
+          "
           class="option"
           @click="$emit('billing')"
         >
@@ -75,7 +99,7 @@
         </div>
 
         <div
-          v-if="role === ORG_ROLE_ADMIN"
+          v-if="!isAccessDisabled && role === ORG_ROLE_ADMIN"
           class="option"
           @click="$emit('edit')"
         >
@@ -112,6 +136,11 @@ import {
   ORG_ROLE_ADMIN,
   ORG_ROLE_FINANCIAL,
 } from './orgListItem.vue';
+import {
+  ACCESS_STATUS_ACTIVE,
+  ACCESS_STATUS_DISABLED,
+  getOrgAccessDisabledMessage,
+} from '@/utils/orgAccess';
 
 export default {
   props: {
@@ -119,6 +148,18 @@ export default {
     description: String,
     plan: String,
     role: Number,
+    accessStatus: {
+      type: String,
+      default: ACCESS_STATUS_ACTIVE,
+    },
+    accessDisabledReason: {
+      type: String,
+      default: null,
+    },
+    ssoConfig: {
+      type: Object,
+      default: () => ({}),
+    },
   },
 
   data() {
@@ -132,6 +173,24 @@ export default {
   },
 
   computed: {
+    isAccessDisabled() {
+      return this.accessStatus === ACCESS_STATUS_DISABLED;
+    },
+
+    disabledTooltipText() {
+      return getOrgAccessDisabledMessage(
+        {
+          access_disabled_reason: this.accessDisabledReason,
+          sso_config: this.ssoConfig,
+        },
+        this.$t.bind(this),
+      );
+    },
+
+    showOptionsMenu() {
+      return this.role === ORG_ROLE_ADMIN;
+    },
+
     planTagScheme() {
       const schemesByPlan = {
         trial: 'blue',
@@ -142,6 +201,20 @@ export default {
       };
 
       return schemesByPlan[this.plan] || 'gray';
+    },
+  },
+
+  methods: {
+    onCardClick() {
+      if (this.isAccessDisabled) {
+        return;
+      }
+
+      if (this.role === ORG_ROLE_FINANCIAL) {
+        this.$emit('billing');
+      } else {
+        this.$emit('enter');
+      }
     },
   },
 };
@@ -169,6 +242,45 @@ export default {
     box-shadow: $unnnic-shadow-1;
   }
 
+  &--disabled {
+    cursor: default;
+    opacity: 0.7;
+
+    &:hover {
+      box-shadow: none;
+    }
+
+    .org-card__content {
+      cursor: not-allowed;
+
+      :deep(.unnnic-tooltip-trigger) {
+        cursor: pointer;
+      }
+    }
+
+    .name,
+    .description {
+      color: $unnnic-color-fg-muted;
+    }
+  }
+
+  &__content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__options {
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .name-row {
+    display: flex;
+    align-items: center;
+    column-gap: $unnnic-spacing-xs;
+    margin-bottom: $unnnic-spacing-ant;
+  }
+
   .name {
     color: $unnnic-color-neutral-black;
 
@@ -178,7 +290,6 @@ export default {
     line-height: $unnnic-font-size-title-md + $unnnic-line-height-md;
 
     margin: 0;
-    margin-bottom: $unnnic-spacing-ant;
   }
 
   .description {

--- a/src/components/orgs/OrgCard.vue
+++ b/src/components/orgs/OrgCard.vue
@@ -5,7 +5,7 @@
     @click="onCardClick"
   >
     <div class="org-card__content">
-      <div class="name-row">
+      <div class="org-card__name-row">
         <h2 class="name">{{ name }}</h2>
 
         <UnnnicToolTip
@@ -188,7 +188,21 @@ export default {
     },
 
     showOptionsMenu() {
-      return this.role === ORG_ROLE_ADMIN;
+      const rolesWithMenu = [
+        ORG_ROLE_ADMIN,
+        ORG_ROLE_CONTRIBUTOR,
+        ORG_ROLE_FINANCIAL,
+      ];
+
+      if (!rolesWithMenu.includes(this.role)) {
+        return false;
+      }
+
+      if (this.role === ORG_ROLE_ADMIN) {
+        return true;
+      }
+
+      return !this.isAccessDisabled;
     },
 
     planTagScheme() {
@@ -274,7 +288,7 @@ export default {
     flex-shrink: 0;
   }
 
-  .name-row {
+  &__name-row {
     display: flex;
     align-items: center;
     column-gap: $unnnic-spacing-xs;

--- a/src/components/orgs/orgList.vue
+++ b/src/components/orgs/orgList.vue
@@ -8,6 +8,9 @@
         :description="org.description"
         :plan="org.organization_billing.plan || ''"
         :role="org.authorization.role"
+        :accessStatus="org.access_status"
+        :accessDisabledReason="org.access_disabled_reason"
+        :ssoConfig="org.sso_config"
         @enter="onSelectOrg(org)"
         @view="onViewPermissions(org)"
         @manage="onEditPermissions(org)"
@@ -77,6 +80,7 @@
 import OrgCard from './OrgCard.vue';
 import { mapActions, mapState, mapGetters } from 'vuex';
 import NewInfiniteLoading from '../NewInfiniteLoading.vue';
+import { isOrgAccessDisabled } from '@/utils/orgAccess';
 
 export default {
   // eslint-disable-next-line vue/multi-word-component-names
@@ -252,6 +256,10 @@ export default {
       }, 100);
     },
     onEdit(org) {
+      if (isOrgAccessDisabled(org)) {
+        return;
+      }
+
       this.$store.dispatch('openRightBar', {
         props: {
           type: 'OrgSettings',
@@ -260,6 +268,10 @@ export default {
       });
     },
     onEditPermissions(org) {
+      if (isOrgAccessDisabled(org)) {
+        return;
+      }
+
       this.$store.dispatch('openRightBar', {
         props: {
           type: 'OrgManageUsers',
@@ -268,6 +280,10 @@ export default {
       });
     },
     onViewPermissions(org) {
+      if (isOrgAccessDisabled(org)) {
+        return;
+      }
+
       this.$store.dispatch('openRightBar', {
         props: {
           type: 'OrgReadUsers',
@@ -276,10 +292,18 @@ export default {
       });
     },
     selectOrg(org) {
+      if (isOrgAccessDisabled(org)) {
+        return;
+      }
+
       this.setCurrentOrg(org);
       this.clearCurrentProject();
     },
     onSelectOrg(org) {
+      if (isOrgAccessDisabled(org)) {
+        return;
+      }
+
       this.selectOrg(org);
       this.$router.push({
         name: 'projects',
@@ -289,6 +313,10 @@ export default {
       });
     },
     onNavigateToBilling(org) {
+      if (isOrgAccessDisabled(org)) {
+        return;
+      }
+
       this.selectOrg(org);
       this.$router.push({
         name: 'billing',

--- a/src/components/orgs/orgList.vue
+++ b/src/components/orgs/orgList.vue
@@ -168,6 +168,14 @@ export default {
       'openModal',
     ]),
 
+    runIfOrgAccessible(org, callback) {
+      if (isOrgAccessDisabled(org)) {
+        return;
+      }
+
+      return callback(org);
+    },
+
     openLeaveConfirmation(organization) {
       this.openModal({
         type: 'confirm',
@@ -256,73 +264,59 @@ export default {
       }, 100);
     },
     onEdit(org) {
-      if (isOrgAccessDisabled(org)) {
-        return;
-      }
-
-      this.$store.dispatch('openRightBar', {
-        props: {
-          type: 'OrgSettings',
-          orgUuid: org.uuid,
-        },
+      this.runIfOrgAccessible(org, () => {
+        this.$store.dispatch('openRightBar', {
+          props: {
+            type: 'OrgSettings',
+            orgUuid: org.uuid,
+          },
+        });
       });
     },
     onEditPermissions(org) {
-      if (isOrgAccessDisabled(org)) {
-        return;
-      }
-
-      this.$store.dispatch('openRightBar', {
-        props: {
-          type: 'OrgManageUsers',
-          orgUuid: org.uuid,
-        },
+      this.runIfOrgAccessible(org, () => {
+        this.$store.dispatch('openRightBar', {
+          props: {
+            type: 'OrgManageUsers',
+            orgUuid: org.uuid,
+          },
+        });
       });
     },
     onViewPermissions(org) {
-      if (isOrgAccessDisabled(org)) {
-        return;
-      }
-
-      this.$store.dispatch('openRightBar', {
-        props: {
-          type: 'OrgReadUsers',
-          orgUuid: org.uuid,
-        },
+      this.runIfOrgAccessible(org, () => {
+        this.$store.dispatch('openRightBar', {
+          props: {
+            type: 'OrgReadUsers',
+            orgUuid: org.uuid,
+          },
+        });
       });
     },
     selectOrg(org) {
-      if (isOrgAccessDisabled(org)) {
-        return;
-      }
-
       this.setCurrentOrg(org);
       this.clearCurrentProject();
     },
     onSelectOrg(org) {
-      if (isOrgAccessDisabled(org)) {
-        return;
-      }
-
-      this.selectOrg(org);
-      this.$router.push({
-        name: 'projects',
-        params: {
-          orgUuid: org.uuid,
-        },
+      this.runIfOrgAccessible(org, () => {
+        this.selectOrg(org);
+        this.$router.push({
+          name: 'projects',
+          params: {
+            orgUuid: org.uuid,
+          },
+        });
       });
     },
     onNavigateToBilling(org) {
-      if (isOrgAccessDisabled(org)) {
-        return;
-      }
-
-      this.selectOrg(org);
-      this.$router.push({
-        name: 'billing',
-        params: {
-          orgUuid: org.uuid,
-        },
+      this.runIfOrgAccessible(org, () => {
+        this.selectOrg(org);
+        this.$router.push({
+          name: 'billing',
+          params: {
+            orgUuid: org.uuid,
+          },
+        });
       });
     },
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -563,6 +563,7 @@
       "username": "Username",
       "contact": "Contact",
       "password": "New password",
+      "password_message": "Changing your password will remove your access to organizations that require mandatory SSO login.",
       "receiveOffers": "Marketing information",
       "receiveOffers_text": "I want to receive communications and personalized offers based on my interests",
       "info_validation": "Review the information provided during registration on the platform and enter your contact details. Your phone number will help us contact you for support or special offers."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -653,6 +653,13 @@
     "add_org_and_project": "Create organization and project",
     "add_org": "Create organization",
     "about_org": "About the organization",
+    "access_disabled_reason": {
+      "sso_credential_unavailable": "Access couldn't be verified due to a technical issue. Try again later",
+      "sso_email_domain_not_allowed": "Your email domain isn't allowed in this organization. Contact the organization admin",
+      "sso_password_configured": "Access requires signing in with SSO only. Remove your password in account settings",
+      "sso_provider_not_allowed": "Sign in with an allowed SSO provider to access this organization: {providers}",
+      "sso_session_required": "Sign in with SSO (Google or Microsoft) to access this organization"
+    },
     "add_project": "Create project",
     "join": "Join",
     "view_members": "View members",
@@ -660,6 +667,20 @@
     "billing": "Billing",
     "reached_active_contacts_limit": "Your organization has reached {limit} active contacts.",
     "select_a_plan": "Select a plan",
+    "sso": {
+      "allowed_domains": "Allowed domains",
+      "allowed_domains_placeholder": "yourcompany.com",
+      "description": "Require all organization members to sign in exclusively through Single Sign-On. Users who currently access the platform with a password will lose that access and must authenticate through your identity provider.",
+      "enable": "Enable mandatory SSO",
+      "helper": "When enabled, password-based login will be disabled for all users in this organization.",
+      "lockout_error": {
+        "description": "Make sure at least one admin in your organization has SSO access before enabling this setting.",
+        "title": "SSO login required for at least one admin"
+      },
+      "provider_label": "Sign-in provider",
+      "provider_placeholder": "Select",
+      "title": "Mandatory SSO login"
+    },
     "users": {
       "leave": "Leave organization",
       "left": "You left the {name} organization",
@@ -669,6 +690,7 @@
       "already_in": "This user is already in the organization"
     },
     "config": "Settings",
+    "settings_title": "Organization settings",
     "security": "Security",
     "general": "General",
     "recommended": "Recommended",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -653,6 +653,13 @@
     "add_org_and_project": "Crear organización y proyecto",
     "add_org": "Crear organización",
     "about_org": "Acerca de la organización",
+    "access_disabled_reason": {
+      "sso_credential_unavailable": "No se pudo verificar el acceso debido a un problema técnico. Inténtalo de nuevo más tarde",
+      "sso_email_domain_not_allowed": "El dominio de tu correo no está permitido en esta organización. Contacta al administrador de la organización",
+      "sso_password_configured": "El acceso requiere iniciar sesión solo con SSO. Elimina tu contraseña en la configuración de la cuenta",
+      "sso_provider_not_allowed": "Inicia sesión con un proveedor de SSO permitido para acceder a esta organización: {providers}",
+      "sso_session_required": "Inicia sesión con SSO (Google o Microsoft) para acceder a esta organización"
+    },
     "add_project": "Crear proyecto",
     "join": "Entra",
     "view_members": "Ver contactos",
@@ -660,6 +667,20 @@
     "billing": "Facturación",
     "reached_active_contacts_limit": "Su organización ha alcanzado {limit} contactos activos.",
     "select_a_plan": "Seleccione un plan",
+    "sso": {
+      "allowed_domains": "Dominios permitidos",
+      "allowed_domains_placeholder": "tuempresa.com",
+      "description": "Exige que todos los miembros de la organización inicien sesión exclusivamente mediante Single Sign-On. Quienes acceden a la plataforma con contraseña perderán ese acceso y deberán autenticarse mediante tu proveedor de identidad.",
+      "enable": "Habilitar SSO obligatorio",
+      "helper": "Cuando está habilitado, el inicio de sesión con contraseña se desactiva para todos los usuarios de esta organización.",
+      "lockout_error": {
+        "description": "Asegúrate de que al menos un administrador de tu organización tenga acceso mediante SSO antes de habilitar esta configuración.",
+        "title": "Inicio de sesión SSO obligatorio para al menos un administrador"
+      },
+      "provider_label": "Proveedor de inicio de sesión",
+      "provider_placeholder": "Seleccionar",
+      "title": "Inicio de sesión SSO obligatorio"
+    },
     "users": {
       "leave": "Dejar la organización",
       "left": "¡Has dejado la organización {name}!",
@@ -678,6 +699,7 @@
       }
     },
     "config": "Ajustes",
+    "settings_title": "Configuración de la organización",
     "security": "Seguridad",
     "general": "General",
     "recommended": "Recomendado",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -563,6 +563,7 @@
       "username": "Nombre de usuario",
       "contact": "Contacto",
       "password": "Nueva contraseña",
+      "password_message": "Al cambiar tu contraseña, eliminarás el acceso a organizaciones que requieren inicio de sesión obligatorio mediante SSO.",
       "receiveOffers": "Información de marketing",
       "receiveOffers_text": "Deseo recibir comunicados y ofertas personalizadas según mis intereses",
       "info_validation": "Por favor, valida la información proporcionada durante el registro en la plataforma e ingresa tu contacto. Tu número de teléfono nos ayudará a comunicarnos contigo para brindarte soporte o en posibles promociones"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -563,6 +563,7 @@
       "username": "Username",
       "contact": "Contato",
       "password": "Nova senha",
+      "password_message": "A alteração da sua senha removerá o acesso a organizações que exigem login obrigatório via SSO.",
       "receiveOffers": "Informações de Marketing",
       "receiveOffers_text": "Eu desejo receber comunicados e ofertas personalizadas de acordo com meus interesses",
       "info_validation": "Valide as informações fornecidas durante o cadastro na plataforma e insira o seu contato. O número de telefone/celular nos auxiliará a falar com você para prestar suporte ou em possíveis promoções"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -653,6 +653,13 @@
     "add_org_and_project": "Criar organização e projeto",
     "add_org": "Criar organização",
     "about_org": "Sobre a organização",
+    "access_disabled_reason": {
+      "sso_credential_unavailable": "Não foi possível verificar o acesso devido a um problema técnico. Tente novamente mais tarde",
+      "sso_email_domain_not_allowed": "O domínio do seu email não é permitido nesta organização. Entre em contato com o administrador da organização",
+      "sso_password_configured": "O acesso exige login somente via SSO. Remova sua senha nas configurações da conta",
+      "sso_provider_not_allowed": "Faça login com um provedor de SSO permitido para acessar esta organização: {providers}",
+      "sso_session_required": "Faça login com SSO (Google ou Microsoft) para acessar esta organização"
+    },
     "add_project": "Criar projeto",
     "join": "Entrar",
     "view_members": "Visualizar contatos",
@@ -660,6 +667,20 @@
     "billing": "Faturamento",
     "reached_active_contacts_limit": "Sua organização atingiu {limit} contatos ativos.",
     "select_a_plan": "Selecionar um plano",
+    "sso": {
+      "allowed_domains": "Domínios permitidos",
+      "allowed_domains_placeholder": "suaempresa.com",
+      "description": "Exija que todos os membros da organização façam login exclusivamente por Single Sign-On. Quem acessa a plataforma com senha perderá esse acesso e precisará se autenticar pelo seu provedor de identidade.",
+      "enable": "Habilitar SSO obrigatório",
+      "helper": "Quando habilitado, o login por senha será desativado para todos os usuários desta organização.",
+      "lockout_error": {
+        "description": "Garanta que pelo menos um administrador da sua organização tenha acesso via SSO antes de habilitar esta configuração.",
+        "title": "Login SSO obrigatório para pelo menos um administrador"
+      },
+      "provider_label": "Provedor de login",
+      "provider_placeholder": "Selecionar",
+      "title": "Login SSO obrigatório"
+    },
     "users": {
       "leave": "Sair da organização",
       "left": "Você saiu da organização {name}!",
@@ -678,6 +699,7 @@
       }
     },
     "config": "Configurações",
+    "settings_title": "Configurações da organização",
     "security": "Segurança",
     "general": "Geral",
     "recommended": "Recomendado",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -563,6 +563,7 @@
       "username": "Nume utilizator",
       "contact": "Contact",
       "password": "Parolă nouă",
+      "password_message": "Schimbarea parolei va elimina accesul la organizații care necesită login obligatoriu prin SSO.",
       "receiveOffers": "Informații de marketing",
       "receiveOffers_text": "Vreau să primesc comunicări și oferte personalizate bazate pe interesele mele",
       "info_validation": "Revizuiește informațiile furnizate în timpul înregistrării pe platformă și introdu datele tale de contact. Numărul tău de telefon ne va ajuta să te contactăm pentru asistență sau oferte speciale."

--- a/src/store/org/actions.js
+++ b/src/store/org/actions.js
@@ -102,6 +102,8 @@ export default {
       enforce_2fa,
       is_suspended,
       show_chat_help,
+      access_status,
+      access_disabled_reason,
     } = {},
   ) {
     commit('setCurrentOrg', {
@@ -114,6 +116,8 @@ export default {
       enforce_2fa,
       is_suspended,
       show_chat_help,
+      access_status,
+      access_disabled_reason,
     });
   },
 

--- a/src/utils/orgAccess.js
+++ b/src/utils/orgAccess.js
@@ -1,0 +1,34 @@
+const SSO_PROVIDER_LABELS = {
+  google: 'Google',
+  microsoft: 'Microsoft',
+};
+
+export const ACCESS_STATUS_ACTIVE = 'active';
+export const ACCESS_STATUS_DISABLED = 'disabled';
+
+export function isOrgAccessDisabled(org) {
+  return org?.access_status === ACCESS_STATUS_DISABLED;
+}
+
+function formatAllowedProviders(providers = []) {
+  return providers
+    .map((provider) => SSO_PROVIDER_LABELS[provider] || provider)
+    .join(', ');
+}
+
+export function getOrgAccessDisabledMessage(
+  { access_disabled_reason: reason, sso_config: ssoConfig } = {},
+  t,
+) {
+  if (!reason) {
+    return '';
+  }
+
+  const key = `orgs.access_disabled_reason.${reason}`;
+  const params =
+    reason === 'sso_provider_not_allowed'
+      ? { providers: formatAllowedProviders(ssoConfig?.allowed_sso_providers) }
+      : {};
+
+  return t(key, params);
+}

--- a/src/views/account.vue
+++ b/src/views/account.vue
@@ -169,6 +169,7 @@
               :errors="errorFor('password') || message(error.password)"
               :nativeType="passwordVisible ? 'text' : 'password'"
               :disabled="!accountProfile.can_update_password"
+              :message="$t('account.fields.password_message')"
               @update:model-value="error.password = ''"
               @icon-right-click="togglePasswordVisibility"
             />

--- a/tests/unit/__mocks__/org.js
+++ b/tests/unit/__mocks__/org.js
@@ -2,6 +2,13 @@ module.exports = {
   uuid: '123',
   name: 'Name Lorem ipsum',
   description: 'Description Lorem ipsum',
+  access_status: 'active',
+  access_disabled_reason: null,
+  sso_config: {
+    is_enabled: false,
+    allowed_email_domains: [],
+    allowed_sso_providers: [],
+  },
   organization_billing: {
     id: 1234,
     cycle: 'billing_monthly',

--- a/tests/unit/unit/components/common/RightBar/UpdateOrgSSO.spec.js
+++ b/tests/unit/unit/components/common/RightBar/UpdateOrgSSO.spec.js
@@ -1,0 +1,294 @@
+import { vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import UpdateOrg from '@/components/common/RightBar/updateOrg.vue';
+import orgs from '@/api/orgs';
+import Unnnic from '@weni/unnnic-system';
+
+vi.mock('@/api/orgs', () => ({
+  default: {
+    updateSSOConfig: vi.fn(),
+  },
+}));
+
+vi.mock('@/api/account', () => ({
+  default: {
+    updateAccount2FAStatus: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/openServerErrorAlertModal', () => ({
+  openAlertModal: vi.fn(),
+}));
+
+vi.mock('@weni/unnnic-system', () => ({
+  default: {
+    unnnicCallAlert: vi.fn(),
+  },
+}));
+
+function buildOrg(overrides = {}) {
+  return {
+    uuid: '123',
+    name: 'Acme',
+    description: 'Acme org',
+    enforce_2fa: false,
+    sso_config: {
+      is_enabled: false,
+      allowed_email_domains: [],
+      allowed_sso_providers: [],
+    },
+    ...overrides,
+  };
+}
+
+function mountComponent(org) {
+  const store = createStore({
+    state: {
+      Org: { orgs: { data: [org] } },
+    },
+    actions: {
+      editOrg: vi.fn(),
+      getOrgs: vi.fn(),
+      deleteOrg: vi.fn(),
+      setCurrentOrg: vi.fn(),
+      clearCurrentOrg: vi.fn(),
+      clearCurrentProject: vi.fn(),
+      openModal: vi.fn(),
+    },
+  });
+
+  return shallowMount(UpdateOrg, {
+    global: {
+      plugins: [store],
+      mocks: {
+        $t: (key) => key,
+      },
+    },
+    props: {
+      orgUuid: org.uuid,
+      activeTab: 'second',
+    },
+  });
+}
+
+describe('UpdateOrg.vue - SSO settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('mounted initialization', () => {
+    it('hydrates the SSO form from the org config', () => {
+      const org = buildOrg({
+        sso_config: {
+          is_enabled: true,
+          allowed_email_domains: ['acme.com'],
+          allowed_sso_providers: ['google'],
+        },
+      });
+
+      const wrapper = mountComponent(org);
+
+      expect(wrapper.vm.ssoForm).toEqual({
+        isEnabled: true,
+        provider: 'google',
+        domains: ['acme.com'],
+        domainInput: '',
+      });
+    });
+  });
+
+  describe('addDomain', () => {
+    it('normalizes the value, strips a leading @ and clears the input', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domainInput = '  @Acme.COM ';
+      wrapper.vm.addDomain();
+
+      expect(wrapper.vm.ssoForm.domains).toEqual(['acme.com']);
+      expect(wrapper.vm.ssoForm.domainInput).toBe('');
+    });
+
+    it('ignores empty values and duplicates', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domains = ['acme.com'];
+
+      wrapper.vm.ssoForm.domainInput = '   ';
+      wrapper.vm.addDomain();
+      wrapper.vm.ssoForm.domainInput = 'acme.com';
+      wrapper.vm.addDomain();
+
+      expect(wrapper.vm.ssoForm.domains).toEqual(['acme.com']);
+    });
+  });
+
+  describe('removeDomain', () => {
+    it('removes the given domain', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domains = ['acme.com', 'other.com'];
+      wrapper.vm.removeDomain('acme.com');
+
+      expect(wrapper.vm.ssoForm.domains).toEqual(['other.com']);
+    });
+  });
+
+  describe('ssoFormAsConfig', () => {
+    it('maps the single provider to a one-item list', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.isEnabled = true;
+      wrapper.vm.ssoForm.provider = 'microsoft';
+      wrapper.vm.ssoForm.domains = ['acme.com'];
+
+      expect(wrapper.vm.ssoFormAsConfig).toEqual({
+        is_enabled: true,
+        allowed_email_domains: ['acme.com'],
+        allowed_sso_providers: ['microsoft'],
+      });
+    });
+
+    it('produces an empty providers list when none is selected', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      expect(wrapper.vm.ssoFormAsConfig.allowed_sso_providers).toEqual([]);
+    });
+  });
+
+  describe('ssoValid', () => {
+    it('is valid when SSO is disabled', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.isEnabled = false;
+
+      expect(wrapper.vm.ssoValid).toBe(true);
+    });
+
+    it('requires a provider and at least one domain when enabled', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.isEnabled = true;
+      wrapper.vm.ssoForm.provider = null;
+      wrapper.vm.ssoForm.domains = [];
+      expect(wrapper.vm.ssoValid).toBe(false);
+
+      wrapper.vm.ssoForm.provider = 'google';
+      expect(wrapper.vm.ssoValid).toBe(false);
+
+      wrapper.vm.ssoForm.domains = ['acme.com'];
+      expect(wrapper.vm.ssoValid).toBe(true);
+    });
+  });
+
+  describe('isSaveDisabled', () => {
+    it('is disabled when nothing changed', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      expect(wrapper.vm.isSaveDisabled).toBe(true);
+    });
+
+    it('is disabled when the SSO change is invalid', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.isEnabled = true;
+
+      expect(wrapper.vm.ssoDirty).toBe(true);
+      expect(wrapper.vm.isSaveDisabled).toBe(true);
+    });
+
+    it('is enabled when the SSO change is valid', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.isEnabled = true;
+      wrapper.vm.ssoForm.provider = 'google';
+      wrapper.vm.ssoForm.domains = ['acme.com'];
+
+      expect(wrapper.vm.isSaveDisabled).toBe(false);
+    });
+
+    it('is enabled when only 2FA changed', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.enable2FA = true;
+
+      expect(wrapper.vm.isSaveDisabled).toBe(false);
+    });
+  });
+
+  describe('saveChanges', () => {
+    it('persists the SSO config and shows a success toast', async () => {
+      const org = buildOrg();
+      const wrapper = mountComponent(org);
+
+      orgs.updateSSOConfig.mockResolvedValue({
+        data: {
+          is_enabled: true,
+          allowed_email_domains: ['acme.com'],
+          allowed_sso_providers: ['google'],
+        },
+      });
+
+      wrapper.vm.ssoForm.isEnabled = true;
+      wrapper.vm.ssoForm.provider = 'google';
+      wrapper.vm.ssoForm.domains = ['acme.com'];
+
+      await wrapper.vm.saveChanges();
+
+      expect(orgs.updateSSOConfig).toHaveBeenCalledWith({
+        organizationUuid: '123',
+        isEnabled: true,
+        allowedEmailDomains: ['acme.com'],
+        allowedSSOProviders: ['google'],
+      });
+      expect(Unnnic.unnnicCallAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({ scheme: 'feedback-green' }),
+        }),
+      );
+    });
+
+    it('shows the lockout error toast and skips 2FA on a 400 response', async () => {
+      const org = buildOrg({ enforce_2fa: false });
+      const wrapper = mountComponent(org);
+
+      orgs.updateSSOConfig.mockRejectedValue({
+        response: { status: 400, data: { detail: 'locked out' } },
+      });
+
+      const spy2FA = vi.spyOn(wrapper.vm, 'beforeUpdate2FAVerification');
+
+      wrapper.vm.ssoForm.isEnabled = true;
+      wrapper.vm.ssoForm.provider = 'google';
+      wrapper.vm.ssoForm.domains = ['acme.com'];
+      wrapper.vm.enable2FA = true;
+
+      await wrapper.vm.saveChanges();
+
+      expect(Unnnic.unnnicCallAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({
+            scheme: 'feedback-red',
+            title: 'SSO login required for at least one admin',
+          }),
+        }),
+      );
+      expect(spy2FA).not.toHaveBeenCalled();
+    });
+
+    it('runs the 2FA flow when only 2FA changed', async () => {
+      const wrapper = mountComponent(buildOrg({ enforce_2fa: false }));
+
+      const spy2FA = vi
+        .spyOn(wrapper.vm, 'beforeUpdate2FAVerification')
+        .mockImplementation(() => {});
+
+      wrapper.vm.enable2FA = true;
+
+      await wrapper.vm.saveChanges();
+
+      expect(orgs.updateSSOConfig).not.toHaveBeenCalled();
+      expect(spy2FA).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/unit/components/common/RightBar/UpdateOrgSSO.spec.js
+++ b/tests/unit/unit/components/common/RightBar/UpdateOrgSSO.spec.js
@@ -134,28 +134,6 @@ describe('UpdateOrg.vue - SSO settings', () => {
     });
   });
 
-  describe('ssoFormAsConfig', () => {
-    it('maps the single provider to a one-item list', () => {
-      const wrapper = mountComponent(buildOrg());
-
-      wrapper.vm.ssoForm.isEnabled = true;
-      wrapper.vm.ssoForm.provider = 'microsoft';
-      wrapper.vm.ssoForm.domains = ['acme.com'];
-
-      expect(wrapper.vm.ssoFormAsConfig).toEqual({
-        is_enabled: true,
-        allowed_email_domains: ['acme.com'],
-        allowed_sso_providers: ['microsoft'],
-      });
-    });
-
-    it('produces an empty providers list when none is selected', () => {
-      const wrapper = mountComponent(buildOrg());
-
-      expect(wrapper.vm.ssoFormAsConfig.allowed_sso_providers).toEqual([]);
-    });
-  });
-
   describe('ssoValid', () => {
     it('is valid when SSO is disabled', () => {
       const wrapper = mountComponent(buildOrg());
@@ -246,6 +224,7 @@ describe('UpdateOrg.vue - SSO settings', () => {
           props: expect.objectContaining({ scheme: 'feedback-green' }),
         }),
       );
+      expect(wrapper.vm.isSaveDisabled).toBe(true);
     });
 
     it('shows the lockout error toast and skips 2FA on a 400 response', async () => {

--- a/tests/unit/unit/components/orgs/OrgCard.spec.js
+++ b/tests/unit/unit/components/orgs/OrgCard.spec.js
@@ -1,0 +1,118 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import OrgCard from '@/components/orgs/OrgCard.vue';
+import {
+  ORG_ROLE_ADMIN,
+  ORG_ROLE_CONTRIBUTOR,
+  ORG_ROLE_FINANCIAL,
+} from '@/components/orgs/orgListItem.vue';
+import { ACCESS_STATUS_DISABLED } from '@/utils/orgAccess';
+
+describe('OrgCard.vue', () => {
+  const defaultProps = {
+    name: 'Test Org',
+    description: 'Test description',
+    plan: 'trial',
+    role: ORG_ROLE_ADMIN,
+  };
+
+  const mountCard = (props = {}) =>
+    shallowMount(OrgCard, {
+      props: {
+        ...defaultProps,
+        ...props,
+      },
+      global: {
+        stubs: {
+          UnnnicTag: true,
+          UnnnicDropdown: {
+            template: '<div><slot name="trigger" /><slot /></div>',
+          },
+          UnnnicIcon: true,
+          UnnnicIconSvg: true,
+          UnnnicToolTip: {
+            template: '<div class="tooltip-stub"><slot /></div>',
+          },
+        },
+      },
+    });
+
+  describe('when access is active', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mountCard();
+    });
+
+    it('emits enter on card click for admin role', async () => {
+      await wrapper.trigger('click');
+
+      expect(wrapper.emitted('enter')).toHaveLength(1);
+    });
+
+    it('does not apply disabled class', () => {
+      expect(wrapper.classes()).not.toContain('org-card--disabled');
+    });
+
+    it('does not render access tooltip', () => {
+      expect(wrapper.find('.tooltip-stub').exists()).toBe(false);
+    });
+  });
+
+  describe('when access is disabled', () => {
+    const disabledProps = {
+      accessStatus: ACCESS_STATUS_DISABLED,
+      accessDisabledReason: 'sso_session_required',
+    };
+
+    it('applies disabled class', () => {
+      const wrapper = mountCard(disabledProps);
+
+      expect(wrapper.classes()).toContain('org-card--disabled');
+    });
+
+    it('does not emit enter on card click', async () => {
+      const wrapper = mountCard(disabledProps);
+
+      await wrapper.trigger('click');
+
+      expect(wrapper.emitted('enter')).toBeUndefined();
+    });
+
+    it('renders access tooltip', () => {
+      const wrapper = mountCard(disabledProps);
+
+      expect(wrapper.find('.tooltip-stub').exists()).toBe(true);
+    });
+
+    it('shows only leave option for admin', () => {
+      const wrapper = mountCard({
+        ...disabledProps,
+        role: ORG_ROLE_ADMIN,
+      });
+
+      const options = wrapper.findAll('.option');
+
+      expect(options).toHaveLength(1);
+      expect(options[0].text()).toContain('Leave organization');
+    });
+
+    it('hides options menu for contributor', () => {
+      const wrapper = mountCard({
+        ...disabledProps,
+        role: ORG_ROLE_CONTRIBUTOR,
+      });
+
+      expect(wrapper.find('.unnnic-dropdown').exists()).toBe(false);
+    });
+
+    it('hides options menu for financial role', () => {
+      const wrapper = mountCard({
+        ...disabledProps,
+        role: ORG_ROLE_FINANCIAL,
+      });
+
+      expect(wrapper.find('.unnnic-dropdown').exists()).toBe(false);
+    });
+  });
+});

--- a/tests/unit/unit/components/orgs/OrgCard.spec.js
+++ b/tests/unit/unit/components/orgs/OrgCard.spec.js
@@ -57,6 +57,18 @@ describe('OrgCard.vue', () => {
     it('does not render access tooltip', () => {
       expect(wrapper.find('.tooltip-stub').exists()).toBe(false);
     });
+
+    it('renders options menu for contributor role', () => {
+      const contributorWrapper = mountCard({ role: ORG_ROLE_CONTRIBUTOR });
+
+      expect(contributorWrapper.find('.unnnic-dropdown').exists()).toBe(true);
+    });
+
+    it('renders options menu for financial role', () => {
+      const financialWrapper = mountCard({ role: ORG_ROLE_FINANCIAL });
+
+      expect(financialWrapper.find('.unnnic-dropdown').exists()).toBe(true);
+    });
   });
 
   describe('when access is disabled', () => {

--- a/tests/unit/unit/components/orgs/__snapshots__/orgList.spec.js.snap
+++ b/tests/unit/unit/components/orgs/__snapshots__/orgList.spec.js.snap
@@ -11,10 +11,12 @@ exports[`orgList.vue > should be rendered properly 1`] = `
   >
     
     <org-card-stub
+      accessstatus="active"
       data-v-f419c7e3=""
       description="Description Lorem ipsum"
       name="Name Lorem ipsum"
       plan="trial"
+      ssoconfig="[object Object]"
     />
     
     <new-infinite-loading-stub

--- a/tests/unit/unit/components/orgs/orgList.spec.js
+++ b/tests/unit/unit/components/orgs/orgList.spec.js
@@ -144,7 +144,7 @@ describe('orgList.vue', () => {
       access_disabled_reason: 'sso_session_required',
     };
 
-    wrapper.vm.selectOrg(disabledOrg);
+    wrapper.vm.onNavigateToBilling(disabledOrg);
 
     expect(actions.setCurrentOrg).not.toHaveBeenCalled();
   });

--- a/tests/unit/unit/components/orgs/orgList.spec.js
+++ b/tests/unit/unit/components/orgs/orgList.spec.js
@@ -123,4 +123,29 @@ describe('orgList.vue', () => {
 
     expect(isnotAdmin).toBeFalsy();
   });
+
+  it('should not select disabled organization', () => {
+    const disabledOrg = {
+      ...org,
+      access_status: 'disabled',
+      access_disabled_reason: 'sso_session_required',
+    };
+
+    wrapper.vm.onSelectOrg(disabledOrg);
+
+    expect(actions.setCurrentOrg).not.toHaveBeenCalled();
+    expect(actions.clearCurrentProject).not.toHaveBeenCalled();
+  });
+
+  it('should not set current org when access is disabled', () => {
+    const disabledOrg = {
+      ...org,
+      access_status: 'disabled',
+      access_disabled_reason: 'sso_session_required',
+    };
+
+    wrapper.vm.selectOrg(disabledOrg);
+
+    expect(actions.setCurrentOrg).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/unit/utils/orgAccess.spec.js
+++ b/tests/unit/unit/utils/orgAccess.spec.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ACCESS_STATUS_DISABLED,
+  getOrgAccessDisabledMessage,
+  isOrgAccessDisabled,
+} from '@/utils/orgAccess';
+
+describe('orgAccess', () => {
+  const t = (key, params = {}) => {
+    if (params.providers) {
+      return `${key}:${params.providers}`;
+    }
+
+    return key;
+  };
+
+  describe('isOrgAccessDisabled', () => {
+    it('returns true when access_status is disabled', () => {
+      expect(
+        isOrgAccessDisabled({ access_status: ACCESS_STATUS_DISABLED }),
+      ).toBe(true);
+    });
+
+    it('returns false when access_status is active', () => {
+      expect(isOrgAccessDisabled({ access_status: 'active' })).toBe(false);
+    });
+
+    it('returns false when org is undefined', () => {
+      expect(isOrgAccessDisabled()).toBe(false);
+    });
+  });
+
+  describe('getOrgAccessDisabledMessage', () => {
+    it('returns empty string when reason is missing', () => {
+      expect(getOrgAccessDisabledMessage({}, t)).toBe('');
+    });
+
+    it('returns locale key for known reason', () => {
+      expect(
+        getOrgAccessDisabledMessage(
+          { access_disabled_reason: 'sso_session_required' },
+          t,
+        ),
+      ).toBe('orgs.access_disabled_reason.sso_session_required');
+    });
+
+    it('interpolates allowed providers for provider not allowed reason', () => {
+      expect(
+        getOrgAccessDisabledMessage(
+          {
+            access_disabled_reason: 'sso_provider_not_allowed',
+            sso_config: { allowed_sso_providers: ['google', 'microsoft'] },
+          },
+          t,
+        ),
+      ).toBe(
+        'orgs.access_disabled_reason.sso_provider_not_allowed:Google, Microsoft',
+      );
+    });
+  });
+});

--- a/tests/unit/unit/views/org/__snapshots__/orgs.spec.js.snap
+++ b/tests/unit/unit/views/org/__snapshots__/orgs.spec.js.snap
@@ -82,10 +82,12 @@ exports[`orgs.vue > should be rendered properly 1`] = `
           >
             
             <org-card-stub
+              accessstatus="active"
               data-v-f419c7e3=""
               description="Description Lorem ipsum"
               name="Name Lorem ipsum"
               plan="trial"
+              ssoconfig="[object Object]"
             />
             
             <new-infinite-loading-stub


### PR DESCRIPTION
## Description

### Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other

### Motivation and Context

Organizations need the ability to enforce Single Sign-On (SSO) for all members, restricting password-based login and requiring authentication through an approved identity provider. Additionally, when SSO is enforced, users whose accounts don't meet the SSO requirements should be blocked from accessing the organization, with clear feedback explaining why.

### Summary of Changes

**SSO Configuration API**
- Added `getSSOConfig` and `updateSSOConfig` API methods to fetch and patch SSO settings for an organization via `/v1/organization/org/{uuid}/sso-settings/`.

**Organization Settings UI (Security Tab)**
- Expanded the Security tab in the org settings right bar to include an SSO configuration section alongside the existing 2FA toggle.
- Users can enable mandatory SSO, select a sign-in provider (Google or Microsoft), and define allowed email domains (added via Enter key, displayed as removable chips).
- The save button is shared between 2FA and SSO changes, and is disabled when no changes are detected or when SSO is enabled but incomplete (missing provider or domain).
- On save, SSO changes are persisted first; if successful, any pending 2FA changes are then applied.
- Success and error toast notifications are shown after save attempts, including a specific lockout error when no admin has SSO access.

**Organization Access Enforcement**
- Introduced `src/utils/orgAccess.js` with helpers `isOrgAccessDisabled` and `getOrgAccessDisabledMessage` to evaluate an org's `access_status` and `access_disabled_reason` fields.
- `OrgCard` now accepts `accessStatus`, `accessDisabledReason`, and `ssoConfig` props. Disabled orgs render with reduced opacity, a non-allowed cursor, a tooltip explaining the reason, and no clickable navigation. The options menu is hidden for non-admin roles when access is disabled.
- All org navigation and action handlers in `orgList` (select, edit, manage users, view users, billing) guard against disabled access.
- `access_status` and `access_disabled_reason` are now forwarded through the Vuex `setCurrentOrg` action.

**Settings Header**
- Replaced the back-arrow icon in the org settings right bar header with a title ("Organization settings") and a close icon aligned to the right.

**Localization**
- Added SSO-related strings and access-disabled reason messages in English, Spanish, and Brazilian Portuguese.

**Tests**
- Added unit tests for `orgAccess` utilities, `OrgCard` disabled-access behavior, SSO form logic in `UpdateOrg`, and disabled-org guards in `orgList`.