### PR TITLE
refactor: update color scheme and styling across components

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -872,10 +872,10 @@ export default {
     }
 
     &.theme-normal {
-      background-color: $unnnic-color-neutral-light;
+      background-color: $unnnic-color-bg-muted;
 
       .page-container {
-        background-color: $unnnic-color-neutral-snow;
+        background-color: $unnnic-color-bg-base;
       }
     }
   }
@@ -893,7 +893,7 @@ export default {
 
 body {
   margin: 0;
-  background-color: $unnnic-color-neutral-snow;
+  background-color: $unnnic-color-bg-base;
   font-family: $unnnic-font-family-secondary;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/src/assets/scss/unnnic-styles.scss
+++ b/src/assets/scss/unnnic-styles.scss
@@ -13,31 +13,6 @@
 }
 
 .u {
-  $scheme-colors-inverted:
-      /* Neutral */
-      "neutral-black" $unnnic-color-neutral-snow,
-      "neutral-darkest" $unnnic-color-neutral-light,
-      "neutral-dark" $unnnic-color-neutral-lightest,
-      "neutral-cloudy" $unnnic-color-neutral-soft,
-      "neutral-cleanest" $unnnic-color-neutral-clean,
-      "neutral-clean" $unnnic-color-neutral-cleanest,
-      "neutral-soft" $unnnic-color-neutral-cloudy,
-      "neutral-lightest" $unnnic-color-neutral-dark,
-      "neutral-light" $unnnic-color-neutral-darkest,
-      "neutral-snow" $unnnic-color-neutral-black;
-
-  // @each $name, $color in $scheme-colors-inverted {
-  //   body[unnnic-theme=dark] &.bg-#{$name} {
-  //     background-color: $color;
-  //   }
-
-  //   body[unnnic-theme=dark] &.color-#{$name} {
-  //     color: $color;
-  //   }
-  // }
-
-
-
   $font-sizes:
     "body-sm" $unnnic-font-size-body-sm,
     "body-md" $unnnic-font-size-body-md,

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -61,8 +61,8 @@ export default {
   font-family: $unnnic-font-family-secondary;
   border-radius: $unnnic-border-radius-sm;
 
-  background-color: $unnnic-color-background-carpet;
-  box-shadow: $unnnic-shadow-level-near;
+  background-color: $unnnic-color-bg-base-soft;
+  box-shadow: $unnnic-shadow-1;
 
   &.clickable {
     cursor: pointer;
@@ -74,21 +74,21 @@ export default {
 
   &.scheme--feedback-yellow {
     .content .title {
-      color: $unnnic-color-feedback-yellow;
+      color: $unnnic-color-fg-warning;
     }
 
     :deep(high) {
-      color: $unnnic-color-feedback-yellow;
+      color: $unnnic-color-fg-warning;
     }
   }
 
   &.scheme--feedback-blue {
     .content .title {
-      color: $unnnic-color-feedback-blue;
+      color: $unnnic-color-fg-info;
     }
 
     :deep(high) {
-      color: $unnnic-color-feedback-blue;
+      color: $unnnic-color-fg-info;
     }
   }
 
@@ -97,7 +97,7 @@ export default {
     margin: 0 $unnnic-inline-xs;
 
     .title {
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-fg-emphasized;
       font-size: $unnnic-font-size-body-md;
       font-family: $unnnic-font-family-secondary;
       line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
@@ -105,7 +105,7 @@ export default {
     }
 
     .description {
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
       font-size: $unnnic-font-size-body-gt;
       line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
       font-weight: $unnnic-font-weight-regular;
@@ -113,7 +113,7 @@ export default {
   }
 
   .close {
-    color: $unnnic-color-brand-sec;
+    color: $unnnic-color-fg-muted;
     font-size: $unnnic-font-size-body-md;
     line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
     font-weight: $unnnic-font-weight-regular;

--- a/src/components/ApiOptions.vue
+++ b/src/components/ApiOptions.vue
@@ -54,14 +54,14 @@ export default {
 
   a {
     font-family: $unnnic-font-family-secondary;
-    color: $unnnic-color-neutral-clean;
+    color: $unnnic-color-fg-muted;
     font-weight: $unnnic-font-weight-bold;
     font-size: $unnnic-font-size-body-lg;
     line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
     text-decoration: none;
 
     &.router-link-active {
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
     }
   }
 }

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -47,7 +47,7 @@ $avatar-sizes:
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: $unnnic-color-background-snow;
+  background-color: $unnnic-color-bg-base;
   border-radius: 50%;
   margin-right: $unnnic-inline-sm;
   background-size: cover;

--- a/src/components/ContainerCondensed.vue
+++ b/src/components/ContainerCondensed.vue
@@ -66,7 +66,7 @@ $font-sizes:
   .footer {
     width: 100%;
     min-height: $unnnic-border-width-thick * 2;
-    background-color: $unnnic-color-brand-weni;
+    background-color: $unnnic-color-teal-8;
   }
 }
 </style>

--- a/src/components/Emote.vue
+++ b/src/components/Emote.vue
@@ -52,9 +52,9 @@ export default {
   width: $unnnic-avatar-size-sm;
   height: $unnnic-avatar-size-sm;
   border-radius: 50%;
-  background-color: $unnnic-color-background-snow;
+  background-color: $unnnic-color-bg-base;
   user-select: none;
-  box-shadow: $unnnic-shadow-level-separated;
+  box-shadow: $unnnic-shadow-1;
 
   img {
     min-width: $unnnic-avatar-size-sm;

--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -92,7 +92,7 @@ export default {
   &__loading {
     width: 100%;
     text-align: center;
-    color: $unnnic-color-neutral-cleanest;
+    color: $unnnic-color-fg-muted;
     font-family: $unnnic-font-family-secondary;
   }
 }

--- a/src/components/ListOrdinator.vue
+++ b/src/components/ListOrdinator.vue
@@ -35,7 +35,7 @@ export default {
   flex-wrap: wrap;
   font-family: $unnnic-font-family-secondary;
   font-weight: $unnnic-font-weight-regular;
-  color: $unnnic-color-neutral-darkest;
+  color: $unnnic-color-fg-emphasized;
   font-size: $unnnic-font-size-body-gt;
   line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
   column-gap: $unnnic-spacing-sm;

--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -23,7 +23,7 @@ export default {
   width: 100%;
 
   span {
-    color: $unnnic-color-neutral-dark;
+    color: $unnnic-color-fg-base;
   }
 }
 

--- a/src/components/Report.vue
+++ b/src/components/Report.vue
@@ -38,10 +38,10 @@ export default {
 .weni-report {
   display: flex;
   align-items: center;
-  background-color: $unnnic-color-background-carpet;
+  background-color: $unnnic-color-bg-base-soft;
   padding: $unnnic-inset-sm;
   border-radius: $unnnic-border-radius-sm;
-  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+  border: 1px solid $unnnic-color-border-base;
 
   p {
     font-size: $unnnic-font-size-body-gt;
@@ -50,7 +50,7 @@ export default {
     width: 100%;
     margin-left: $unnnic-spacing-inline-xs;
     font-family: $unnnic-font-family-secondary;
-    color: $unnnic-color-neutral-dark;
+    color: $unnnic-color-fg-base;
   }
 }
 </style>

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -400,9 +400,9 @@ $sidebar-width: calc($icon-container-size + ($unnnic-space-3 * 2));
   row-gap: $unnnic-spacing-nano;
 
   + .page-group {
-    margin-top: -$unnnic-spacing-xs - $unnnic-border-width-thinner;
+    margin-top: -$unnnic-spacing-xs - 1px;
     padding-top: $unnnic-spacing-xs;
-    border-top: $unnnic-border-width-thinner solid $unnnic-color-border-base;
+    border-top: 1px solid $unnnic-color-border-base;
   }
 
   &__label {
@@ -479,8 +479,8 @@ $sidebar-width: calc($icon-container-size + ($unnnic-space-3 * 2));
   }
 
   &__footer {
-    margin-top: $unnnic-spacing-xs - $unnnic-border-width-thinner;
-    border-top: $unnnic-border-width-thinner solid $unnnic-color-border-base;
+    margin-top: $unnnic-spacing-xs - 1px;
+    border-top: 1px solid $unnnic-color-border-base;
     padding-top: $unnnic-spacing-xs;
   }
 }

--- a/src/components/Sidebar/SidebarModal.vue
+++ b/src/components/Sidebar/SidebarModal.vue
@@ -3,11 +3,11 @@
     <img :src="image" />
 
     <div class="content">
-      <div class="u font secondary body-md bold color-neutral-dark">
+      <div class="u font secondary body-md bold color-fg-base">
         {{ title }}
       </div>
 
-      <div class="u font secondary body-md color-neutral-cloudy">
+      <div class="u font secondary body-md color-fg-base">
         {{ description }}
       </div>
 
@@ -39,10 +39,10 @@ export default {
 <style lang="scss" scoped>
 .sidebar-modal {
   background-color: $unnnic-color-bg-base-soft;
-  border: $unnnic-border-width-thinner solid $unnnic-color-border-base;
+  border: 1px solid $unnnic-color-border-base;
   border-radius: $unnnic-border-radius-md;
   padding: $unnnic-spacing-inset-nano;
-  box-shadow: $unnnic-shadow-level-separated;
+  box-shadow: $unnnic-shadow-1;
 
   img {
     width: 100%;

--- a/src/components/Sidebar/SidebarOption.vue
+++ b/src/components/Sidebar/SidebarOption.vue
@@ -286,11 +286,11 @@ const commomProps = computed(() => {
   &--expanded-container {
     $spacing-left: 1.25 * $unnnic-font-size;
 
-    margin-left: $spacing-left - $unnnic-border-width-thinner;
+    margin-left: $spacing-left - 1px;
 
     padding-top: $unnnic-spacing-nano;
     padding-left: $unnnic-spacing-ant;
-    border-left: $unnnic-border-width-thinner solid $unnnic-color-border-soft;
+    border-left: 1px solid $unnnic-color-border-soft;
 
     box-sizing: border-box;
   }
@@ -308,8 +308,8 @@ const commomProps = computed(() => {
     padding: $unnnic-spacing-xs;
     border-radius: $unnnic-radius-2;
     background-color: $unnnic-color-bg-base;
-    border: $unnnic-border-width-thinner solid $unnnic-color-border-base;
-    box-shadow: $unnnic-shadow-level-near;
+    border: 1px solid $unnnic-color-border-base;
+    box-shadow: $unnnic-shadow-1;
     width: 14.875 * $unnnic-font-size;
     box-sizing: border-box;
   }

--- a/src/components/Sidebar/SidebarOptionInside.vue
+++ b/src/components/Sidebar/SidebarOptionInside.vue
@@ -217,8 +217,8 @@ $icon-container-size: calc($icon-size + $icon-padding);
   }
 
   &--variant-outline {
-    padding: $unnnic-spacing-xs - $unnnic-border-width-thinner;
-    border: $unnnic-border-width-thinner solid $unnnic-color-border-base;
+    padding: $unnnic-spacing-xs - 1px;
+    border: 1px solid $unnnic-color-border-base;
   }
 
   &--align-center {
@@ -342,7 +342,7 @@ $icon-container-size: calc($icon-size + $icon-padding);
 .option--variant-outline {
   &:hover:not(.option--disabled),
   &.option--selected {
-    border: $unnnic-border-width-thinner solid $unnnic-color-border-base;
+    border: 1px solid $unnnic-color-border-base;
   }
 }
 </style>

--- a/src/components/Topbar/ProfileDropdown.vue
+++ b/src/components/Topbar/ProfileDropdown.vue
@@ -318,7 +318,7 @@ function showLogoutModal() {
     padding: $unnnic-space-4;
     border-radius: $unnnic-radius-4;
     background-color: $unnnic-color-bg-base;
-    box-shadow: $unnnic-shadow-level-near;
+    box-shadow: $unnnic-shadow-1;
     width: 17.5 * $unnnic-font-size;
     box-sizing: border-box;
 

--- a/src/components/Topbar/ProfilePictureDefault.vue
+++ b/src/components/Topbar/ProfilePictureDefault.vue
@@ -42,10 +42,10 @@ defineProps({
 
 <style lang="scss" scoped>
 .background {
-  fill: $unnnic-color-neutral-soft;
+  fill: $unnnic-color-bg-muted;
 }
 
 .text {
-  fill: $unnnic-color-neutral-cloudy;
+  fill: $unnnic-color-fg-base;
 }
 </style>

--- a/src/components/Topbar/Topbar.vue
+++ b/src/components/Topbar/Topbar.vue
@@ -124,8 +124,8 @@ function openNotifications() {
 
   background-color: $unnnic-color-bg-base;
   padding: $unnnic-spacing-xs $unnnic-spacing-sm;
-  padding-bottom: $unnnic-spacing-xs - $unnnic-border-width-thinner;
-  border-bottom: $unnnic-border-width-thinner solid $unnnic-color-border-base;
+  padding-bottom: $unnnic-spacing-xs - 1px;
+  border-bottom: 1px solid $unnnic-color-border-base;
 
   &__logo {
     margin-right: auto;
@@ -160,7 +160,7 @@ function openNotifications() {
     }
 
     &__notification-symbol {
-      $border-width: $unnnic-border-width-thinner;
+      $border-width: 1px;
       $top-spacing: 0.5625 * $unnnic-font-size - $border-width;
       $right-spacing: 0.4375 * $unnnic-font-size - $border-width;
 

--- a/src/components/WarningVerifyMail.vue
+++ b/src/components/WarningVerifyMail.vue
@@ -97,8 +97,8 @@ export default {
 
 <style lang="scss" scoped>
 .warning-bar {
-  background-color: $unnnic-color-aux-orange-500;
-  color: $unnnic-color-neutral-white;
+  background-color: $unnnic-color-bg-warning;
+  color: $unnnic-color-fg-inverted;
   font-family: $unnnic-font-family-secondary;
   font-weight: $unnnic-font-weight-bold;
   font-size: $unnnic-font-size-body-lg;
@@ -110,7 +110,7 @@ export default {
     margin-right: $unnnic-spacing-inline-xs;
 
     :deep(.primary) {
-      fill: $unnnic-color-background-sky;
+      fill: $unnnic-color-bg-base-soft;
     }
   }
 

--- a/src/components/accounts/AccountPreferences.vue
+++ b/src/components/accounts/AccountPreferences.vue
@@ -116,7 +116,7 @@ export default {
     font-weight: $unnnic-font-weight-regular;
     font-size: $unnnic-font-size-title-md;
     line-height: $unnnic-line-height-md + $unnnic-font-size-title-md;
-    color: $unnnic-color-neutral-black;
+    color: $unnnic-color-fg-emphasized;
   }
 
   &__content {
@@ -126,7 +126,7 @@ export default {
 
   &__label {
     font-family: $unnnic-font-size-body-lg;
-    color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-fg-base;
     margin: 0;
   }
 

--- a/src/components/accounts/AccountVerifyTwoFactorsSteps/AccountDownload2FAApp.vue
+++ b/src/components/accounts/AccountVerifyTwoFactorsSteps/AccountDownload2FAApp.vue
@@ -219,13 +219,13 @@ export default {
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-title-md;
       line-height: $unnnic-line-height-md + $unnnic-font-size-title-md;
-      color: $unnnic-color-neutral-black;
+      color: $unnnic-color-fg-emphasized;
     }
 
     p {
       font-size: $unnnic-font-size-body-lg;
       line-height: $unnnic-line-height-md + $unnnic-font-size-body-lg;
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-fg-base;
       margin-top: $unnnic-spacing-stack-xs;
       margin-bottom: $unnnic-spacing-stack-md;
     }
@@ -239,13 +239,13 @@ export default {
       line-height: $unnnic-line-height-md + $unnnic-font-size-body-lg;
       font-weight: $unnnic-font-weight-bold;
       margin: $unnnic-spacing-stack-lg 0 $unnnic-spacing-stack-xs;
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-fg-emphasized;
     }
 
     p {
       font-size: $unnnic-font-size-body-gt;
       line-height: $unnnic-line-height-md + $unnnic-font-size-body-gt;
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-fg-base;
       margin: 0 0 $unnnic-spacing-stack-md;
       font-weight: $unnnic-font-weight-regular;
     }

--- a/src/components/banners/FlowEditorInvitation.vue
+++ b/src/components/banners/FlowEditorInvitation.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="floweditor-invitation">
     <header>
-      <div class="u font body-lg bold color-neutral-snow">
+      <div class="u font body-lg bold color-fg-inverted">
         {{ $t('banners.floweditor_invitation.title') }}
       </div>
     </header>
 
-    <main class="u font secondary body-md color-neutral-snow">
+    <main class="u font secondary body-md color-fg-inverted">
       {{ $t('banners.floweditor_invitation.description') }}
 
       <a
@@ -27,7 +27,7 @@ export default {};
 .floweditor-invitation {
   border-radius: $unnnic-border-radius-md;
   box-sizing: border-box;
-  background-color: $unnnic-color-background-snow;
+  background-color: $unnnic-color-bg-base;
   background-image: url('../../assets/banner/floweditor-invitation-banner-background.svg');
   background-position: right center;
   background-size: cover;

--- a/src/components/billing/InfoBox.vue
+++ b/src/components/billing/InfoBox.vue
@@ -24,18 +24,18 @@ export default {
   padding: $unnnic-spacing-xs $unnnic-spacing-ant;
   border-radius: $unnnic-border-radius-sm;
   outline-style: solid;
-  outline-color: $unnnic-color-aux-yellow-300;
-  outline-width: $unnnic-border-width-thinner;
-  outline-offset: -$unnnic-border-width-thinner;
+  outline-color: $unnnic-color-border-warning;
+  outline-width: 1px;
+  outline-offset: -1px;
 
   font-family: $unnnic-font-family-secondary;
   font-weight: $unnnic-font-weight-regular;
   font-size: $unnnic-font-size-body-md;
   line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
-  color: $unnnic-color-neutral-dark;
+  color: $unnnic-color-fg-base;
 
   background-color: rgba(
-    $unnnic-color-aux-yellow-300,
+    $unnnic-color-yellow-5,
     $unnnic-opacity-level-extra-light
   );
 }

--- a/src/components/billing/Modal.vue
+++ b/src/components/billing/Modal.vue
@@ -78,7 +78,7 @@ export default {
     position: relative;
     padding: $unnnic-spacing-stack-lg $unnnic-inline-xgiant;
     border-radius: $unnnic-border-radius-md;
-    background-color: $unnnic-color-background-sky;
+    background-color: $unnnic-color-bg-base-soft;
     width: 100%;
     max-width: 1157px;
     margin: 0 24px;
@@ -96,12 +96,12 @@ export default {
       }
 
       &::-webkit-scrollbar-thumb {
-        background: $unnnic-color-neutral-clean;
+        background: $unnnic-color-gray-11;
         border-radius: $unnnic-border-radius-pill;
       }
 
       &::-webkit-scrollbar-track {
-        background: $unnnic-color-neutral-soft;
+        background: $unnnic-color-gray-3;
         border-radius: $unnnic-border-radius-pill;
       }
     }
@@ -110,7 +110,7 @@ export default {
       font-size: $unnnic-font-size-title-md;
       font-weight: $unnnic-font-weight-black;
       text-align: center;
-      color: $unnnic-color-brand-sec-dark;
+      color: $unnnic-color-fg-emphasized;
       margin: 0;
     }
 
@@ -119,7 +119,7 @@ export default {
       font-weight: $unnnic-font-weight-regular;
       text-align: center;
       max-width: 680px;
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
       margin: $unnnic-spacing-stack-xs auto 0 auto;
     }
 

--- a/src/components/billing/WarningMaxActiveContacts.vue
+++ b/src/components/billing/WarningMaxActiveContacts.vue
@@ -125,7 +125,7 @@ export default {
   gap: $unnnic-space-1;
 
   &.trial-about-to-end {
-    background-color: $unnnic-color-feedback-yellow;
+    background-color: $unnnic-color-bg-warning;
   }
 
   a {

--- a/src/components/common/MultiSelectRadios.vue
+++ b/src/components/common/MultiSelectRadios.vue
@@ -205,10 +205,10 @@ export default {
 .select-permission,
 .select-content > div {
   padding: $unnnic-squish-xs;
-  background-color: $unnnic-color-neutral-snow;
+  background-color: $unnnic-color-bg-base;
 
   border-radius: $unnnic-border-radius-sm;
-  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+  border: 1px solid $unnnic-color-border-base;
 }
 .select-permission {
   display: flex;
@@ -225,7 +225,7 @@ export default {
 .select-permission-label {
   display: block;
 
-  color: $unnnic-color-neutral-cloudy;
+  color: $unnnic-color-fg-base;
   margin-bottom: $unnnic-spacing-stack-xs;
 
   font-family: $unnnic-font-family-secondary;
@@ -238,7 +238,7 @@ export default {
   font-size: $unnnic-font-size-body-gt;
   margin: 0;
   font-weight: $unnnic-font-weight-regular;
-  color: $unnnic-color-neutral-dark;
+  color: $unnnic-color-fg-base;
 }
 
 .select-content {
@@ -246,7 +246,7 @@ export default {
   margin-top: $unnnic-spacing-stack-xs;
 
   > div {
-    box-shadow: $unnnic-shadow-level-near;
+    box-shadow: $unnnic-shadow-1;
     .title {
       margin-bottom: $unnnic-spacing-stack-sm;
     }
@@ -258,8 +258,8 @@ export default {
       & + h6 {
         margin-top: $unnnic-spacing-stack-sm;
         padding-top: $unnnic-spacing-stack-sm;
-        border-top: $unnnic-border-width-thinner solid
-          $unnnic-color-neutral-darkest;
+        border-top: 1px solid
+          $unnnic-color-border-emphasized;
       }
 
       strong,
@@ -280,8 +280,8 @@ export default {
         & + .unnnic-radio-container {
           margin-top: $unnnic-spacing-stack-sm;
           padding-top: $unnnic-spacing-stack-sm;
-          border-top: $unnnic-border-width-thinner solid
-            $unnnic-color-neutral-lightest;
+          border-top: 1px solid
+            $unnnic-color-border-muted;
         }
 
         :deep(.unnnic-icon) {

--- a/src/components/common/RightBar/Index.vue
+++ b/src/components/common/RightBar/Index.vue
@@ -62,7 +62,7 @@
               {{ texts.title }}
             </h1>
 
-            <h2 class="unnnic-font secondary body-gt color-neutral-cloudy">
+            <h2 class="unnnic-font secondary body-gt color-fg-base">
               {{ texts.description }}
             </h2>
           </div>
@@ -305,7 +305,7 @@ export default {
 
   &__title {
     margin: 0;
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-fg-emphasized;
     font-family: $unnnic-font-family-secondary;
     font-weight: $unnnic-font-weight-bold;
     font-size: $unnnic-font-size-title-sm;
@@ -375,11 +375,10 @@ export default {
 
     &__info {
       padding: $unnnic-spacing-md;
-      padding-bottom: $unnnic-spacing-md - $unnnic-border-width-thinner;
+      padding-bottom: $unnnic-spacing-md - 1px;
       margin: -$unnnic-spacing-lg;
       margin-bottom: $unnnic-spacing-md;
-      border-bottom: $unnnic-border-width-thinner solid
-        $unnnic-color-neutral-soft;
+      border-bottom: 1px solid $unnnic-color-border-base;
 
       display: flex;
       align-items: center;
@@ -393,7 +392,7 @@ export default {
         flex: 1;
 
         h1 {
-          color: $unnnic-color-neutral-darkest;
+          color: $unnnic-color-fg-emphasized;
           font-family: $unnnic-font-family-secondary;
           font-weight: $unnnic-font-weight-bold;
           font-size: $unnnic-font-size-title-sm;

--- a/src/components/common/RightBar/LearningCenter.vue
+++ b/src/components/common/RightBar/LearningCenter.vue
@@ -32,10 +32,9 @@ const projectSelected = computed(() => {
 
 <style lang="scss" scoped>
 hr {
-  margin-block: $unnnic-spacing-md - $unnnic-border-width-thinner
-    $unnnic-spacing-md;
+  margin-block: $unnnic-spacing-md - 1px $unnnic-spacing-md;
 
   border-width: 0;
-  border-top: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+  border-top: 1px solid $unnnic-color-border-base;
 }
 </style>

--- a/src/components/common/RightBar/LearningCenterChampionChatbot.vue
+++ b/src/components/common/RightBar/LearningCenterChampionChatbot.vue
@@ -271,7 +271,7 @@ function leave(el, done) {
       align-items: center;
       column-gap: $unnnic-spacing-xs;
 
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
       font-family: $unnnic-font-family-secondary;
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-body-gt;
@@ -306,7 +306,7 @@ function leave(el, done) {
       p {
         margin: 0;
         margin-top: $unnnic-spacing-xs;
-        color: $unnnic-color-neutral-cloudy;
+        color: $unnnic-color-fg-base;
         font-family: $unnnic-font-family-secondary;
         font-weight: $unnnic-font-weight-regular;
         font-size: $unnnic-font-size-body-gt;
@@ -320,7 +320,7 @@ function leave(el, done) {
 
     &--completed {
       .step__header {
-        color: $unnnic-color-neutral-clean;
+        color: $unnnic-color-fg-base;
 
         &__title {
           text-decoration: line-through;
@@ -339,7 +339,7 @@ function leave(el, done) {
     h3 {
       margin: 0;
 
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-fg-emphasized;
       font-family: $unnnic-font-family-secondary;
       font-weight: $unnnic-font-weight-bold;
       font-size: $unnnic-font-size-body-lg;
@@ -352,7 +352,7 @@ function leave(el, done) {
       column-gap: $unnnic-spacing-xs;
       margin-left: auto;
 
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-fg-base;
       font-family: $unnnic-font-family-secondary;
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-body-md;

--- a/src/components/common/RightBar/LearningCenterResources.vue
+++ b/src/components/common/RightBar/LearningCenterResources.vue
@@ -135,7 +135,7 @@ const resources = computed(() => [
       p {
         margin: 0;
 
-        color: $unnnic-color-neutral-dark;
+        color: $unnnic-color-fg-base;
         font-family: $unnnic-font-family-secondary;
         font-weight: $unnnic-font-weight-regular;
         font-size: $unnnic-font-size-body-gt;
@@ -150,35 +150,35 @@ const resources = computed(() => [
     &:hover {
       h3,
       p {
-        color: $unnnic-color-neutral-darkest;
+        color: $unnnic-color-fg-emphasized;
       }
     }
 
     &--academy {
       .resource__icon__container {
-        color: $unnnic-color-aux-purple-500;
-        background: $unnnic-color-aux-purple-100;
+        color: $unnnic-color-purple-7;
+        background: $unnnic-color-purple-2;
       }
     }
 
     &--docs {
       .resource__icon__container {
-        color: $unnnic-color-aux-blue-500;
-        background: $unnnic-color-aux-blue-100;
+        color: $unnnic-color-blue-7;
+        background: $unnnic-color-blue-2;
       }
     }
 
     &--community {
       .resource__icon__container {
-        color: $unnnic-color-aux-green-500;
-        background: $unnnic-color-aux-green-100;
+        color: $unnnic-color-green-7;
+        background: $unnnic-color-green-2;
       }
     }
 
     &--apis {
       .resource__icon__container {
-        color: $unnnic-color-aux-orange-500;
-        background: $unnnic-color-aux-orange-100;
+        color: $unnnic-color-orange-7;
+        background: $unnnic-color-orange-2;
       }
     }
   }

--- a/src/components/common/RightBar/Notifications.vue
+++ b/src/components/common/RightBar/Notifications.vue
@@ -164,7 +164,7 @@ export default {
     align-items: center;
     column-gap: $unnnic-spacing-xs;
 
-    color: $unnnic-color-neutral-dark;
+    color: $unnnic-color-fg-base;
     font-family: $unnnic-font-family-secondary;
     font-weight: $unnnic-font-weight-regular;
     font-size: $unnnic-font-size-body-gt;
@@ -176,7 +176,7 @@ export default {
     }
 
     .date {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-fg-base;
       white-space: nowrap;
     }
 

--- a/src/components/common/RightBar/NotificationsUpdates.vue
+++ b/src/components/common/RightBar/NotificationsUpdates.vue
@@ -115,7 +115,7 @@ function readMarkdown(content) {
 
 <style lang="scss" scoped>
 .updates {
-  color: $unnnic-color-neutral-dark;
+  color: $unnnic-color-fg-base;
   font-family: $unnnic-font-family-secondary;
   font-weight: $unnnic-font-weight-regular;
   font-size: $unnnic-font-size-body-gt;
@@ -124,7 +124,7 @@ function readMarkdown(content) {
   :deep(h3) {
     margin-block: $unnnic-spacing-md $unnnic-spacing-sm;
 
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-fg-emphasized;
     font-weight: $unnnic-font-weight-bold;
     font-size: $unnnic-font-size-body-lg;
     line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;

--- a/src/components/common/RightBar/ProjectSettings.vue
+++ b/src/components/common/RightBar/ProjectSettings.vue
@@ -319,7 +319,7 @@ onMounted(() => {
     font-size: $unnnic-font-size-body-gt;
     font-weight: $unnnic-font-weight-bold;
     line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-fg-emphasized;
     font-family: $unnnic-font-family-secondary;
     margin: 0;
   }
@@ -331,7 +331,7 @@ onMounted(() => {
     font-size: $unnnic-font-size-body-gt;
     font-weight: $unnnic-font-weight-regular;
     line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-dark;
+    color: $unnnic-color-fg-base;
     font-family: $unnnic-font-family-secondary;
     margin: 0;
   }
@@ -349,7 +349,7 @@ onMounted(() => {
     align-self: stretch;
 
     border-radius: $unnnic-spacing-nano;
-    border: 1px solid $unnnic-color-neutral-soft;
+    border: 1px solid $unnnic-color-border-base;
 
     &__description {
       display: flex;

--- a/src/components/common/RightBar/updateOrg.vue
+++ b/src/components/common/RightBar/updateOrg.vue
@@ -585,7 +585,7 @@ export default {
 }
 
 .separator {
-  border: 1px solid $unnnic-color-neutral-soft;
+  border: 1px solid $unnnic-color-border-base;
   margin: $unnnic-spacing-stack-lg 0;
 }
 
@@ -596,7 +596,7 @@ export default {
   }
 
   &__separator {
-    border: 1px solid $unnnic-color-neutral-soft;
+    border: 1px solid $unnnic-color-border-base;
     margin: $unnnic-spacing-stack-md 0;
   }
 }
@@ -605,7 +605,7 @@ export default {
   h2 {
     margin: 0;
     font-size: $unnnic-font-size-title-sm;
-    color: $unnnic-color-neutral-black;
+    color: $unnnic-color-fg-emphasized;
   }
 
   p {
@@ -613,11 +613,11 @@ export default {
     line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
     margin-top: $unnnic-spacing-stack-xs;
     margin-bottom: $unnnic-spacing-stack-sm;
-    color: $unnnic-color-neutral-dark;
+    color: $unnnic-color-fg-base;
   }
 
   &__button {
-    color: $unnnic-color-feedback-red;
+    color: $unnnic-color-fg-critical;
     width: 100%;
   }
 }
@@ -628,7 +628,7 @@ export default {
   font-weight: $unnnic-font-weight-bold;
   line-height: $unnnic-font-size-title-sm + $unnnic-line-height-md;
   margin: $unnnic-spacing-stack-md 0 $unnnic-spacing-stack-xs;
-  color: $unnnic-color-neutral-black;
+  color: $unnnic-color-fg-emphasized;
 
   .unnnic-tag {
     margin-left: $unnnic-spacing-stack-sm;
@@ -640,7 +640,7 @@ export default {
   font-weight: $unnnic-font-weight-regular;
   line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
   margin: 0;
-  color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-fg-base;
 }
 
 .weni-update-org__security {
@@ -663,7 +663,7 @@ export default {
   line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
   margin: $unnnic-spacing-stack-nano 0 0;
   padding-left: $unnnic-spacing-inline-md + $unnnic-spacing-inline-sm;
-  color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-fg-base;
 }
 
 .weni-update-org__sso-field {
@@ -683,6 +683,6 @@ export default {
   column-gap: $unnnic-spacing-inline-sm;
   margin-top: auto;
   padding-top: $unnnic-spacing-stack-md;
-  border-top: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+  border-top: 1px solid $unnnic-color-border-base;
 }
 </style>

--- a/src/components/dashboard/growth.vue
+++ b/src/components/dashboard/growth.vue
@@ -63,7 +63,7 @@ export default {
 <style lang="scss">
 .weni-growth {
   > * {
-    background-color: $unnnic-color-neutral-snow !important;
+    background-color: $unnnic-color-bg-base !important;
   }
 
   > :not(:last-child) {

--- a/src/components/dashboard/news.vue
+++ b/src/components/dashboard/news.vue
@@ -166,7 +166,7 @@ h2 {
 .weni-news {
   padding: $unnnic-squish-xs;
   font-family: $unnnic-font-family-secondary;
-  color: $unnnic-color-neutral-dark;
+  color: $unnnic-color-fg-base;
   font-size: $unnnic-font-size-body-md;
   line-height: $unnnic-font-size-body-md + $unnnic-line-height-medium;
   border-radius: $unnnic-border-radius-sm;
@@ -210,7 +210,7 @@ h2 {
     width: 0.25rem;
     border-radius: 50%;
     display: inline-block;
-    background-color: $unnnic-color-neutral-clean;
+    background-color: $unnnic-color-gray-11;
     &--active {
       width: 1rem;
       border-radius: 4px;

--- a/src/components/dashboard/newsletter.vue
+++ b/src/components/dashboard/newsletter.vue
@@ -132,9 +132,9 @@ export default {
 .weni-newsletter {
   font-family: $unnnic-font-family-secondary;
   font-size: $unnnic-font-size-body-md;
-  background-color: $unnnic-color-background-snow;
+  background-color: $unnnic-color-bg-base;
   border-radius: 8px;
-  box-shadow: $unnnic-shadow-level-far;
+  box-shadow: $unnnic-shadow-1;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -142,7 +142,7 @@ export default {
 
   &__load-more {
     text-align: center;
-    color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-fg-base;
     padding: $unnnic-inset-md 0;
   }
 
@@ -162,7 +162,7 @@ export default {
     padding: 0 $unnnic-inset-md $unnnic-spacing-stack-lg $unnnic-inset-md;
 
     &__title {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-fg-base;
 
       &__container {
         width: 100%;
@@ -179,20 +179,20 @@ export default {
       }
 
       &__time {
-        color: $unnnic-color-neutral-cloudy;
+        color: $unnnic-color-fg-base;
         font-size: 8px;
       }
     }
 
     &__subtitle {
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-fg-emphasized;
       margin: 0;
     }
   }
 }
 
 ul li::marker {
-  color: $unnnic-color-aux-lemon;
+  color: $unnnic-color-yellow-4;
   font-size: 0.25rem;
 }
 </style>

--- a/src/components/dashboard/status.vue
+++ b/src/components/dashboard/status.vue
@@ -133,7 +133,7 @@ export default {
 <style lang="scss">
 .weni-status {
   > * {
-    background-color: $unnnic-color-neutral-lightest !important;
+    background-color: $unnnic-color-bg-base-soft !important;
   }
   > :not(:last-child) {
     margin-bottom: $unnnic-spacing-stack-sm;

--- a/src/components/external/Modal.vue
+++ b/src/components/external/Modal.vue
@@ -222,12 +222,12 @@ export default {
       }
 
       &::-webkit-scrollbar-thumb {
-        background: $unnnic-color-neutral-clean;
+        background: $unnnic-color-gray-11;
         border-radius: $unnnic-border-radius-pill;
       }
 
       &::-webkit-scrollbar-track {
-        background: $unnnic-color-neutral-soft;
+        background: $unnnic-color-gray-3;
         border-radius: $unnnic-border-radius-pill;
       }
     }
@@ -239,7 +239,7 @@ export default {
       text-align: center;
 
       font-family: $unnnic-font-family-secondary;
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-fg-base;
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-body-lg;
       line-height: ($unnnic-font-size-body-lg + $unnnic-line-height-medium);

--- a/src/components/orgs/OrgCard.vue
+++ b/src/components/orgs/OrgCard.vue
@@ -243,10 +243,10 @@ export default {
 
   outline-style: solid;
   outline-color: $unnnic-color-border-base;
-  outline-width: $unnnic-border-width-thinner;
-  outline-offset: -$unnnic-border-width-thinner;
+  outline-width: 1px;
+  outline-offset: -1px;
 
-  background-color: $unnnic-color-background-white;
+  background-color: $unnnic-color-bg-base;
   padding: $unnnic-spacing-md;
   border-radius: $unnnic-border-radius-md;
 
@@ -296,7 +296,7 @@ export default {
   }
 
   .name {
-    color: $unnnic-color-neutral-black;
+    color: $unnnic-color-fg-emphasized;
 
     font-family: $unnnic-font-family-secondary;
     font-weight: $unnnic-font-weight-bold;
@@ -307,7 +307,7 @@ export default {
   }
 
   .description {
-    color: $unnnic-color-neutral-dark;
+    color: $unnnic-color-fg-base;
 
     font-family: $unnnic-font-family-secondary;
     font-weight: $unnnic-font-weight-regular;
@@ -347,7 +347,7 @@ export default {
       column-gap: $unnnic-spacing-xs;
       align-items: center;
 
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
 
       font-family: $unnnic-font-family-secondary;
       font-weight: $unnnic-font-weight-regular;
@@ -369,8 +369,8 @@ export default {
           pointer-events: none;
           display: block;
           content: ' ';
-          background: $unnnic-color-neutral-light;
-          height: $unnnic-border-width-thinner;
+          background: $unnnic-color-border-muted;
+          height: 1px;
           position: absolute;
           top: 0;
           left: $unnnic-spacing-sm;

--- a/src/components/orgs/UserManagement.vue
+++ b/src/components/orgs/UserManagement.vue
@@ -427,7 +427,7 @@ export default {
       margin: 0;
       line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
       font-size: $unnnic-font-size-body-md;
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
     }
   }
 }
@@ -475,12 +475,12 @@ export default {
   }
 
   &::-webkit-scrollbar-thumb {
-    background: $unnnic-color-neutral-clean;
+    background: $unnnic-color-gray-11;
     border-radius: $unnnic-border-radius-pill;
   }
 
   &::-webkit-scrollbar-track {
-    background: $unnnic-color-neutral-soft;
+    background: $unnnic-color-gray-3;
     border-radius: $unnnic-border-radius-pill;
   }
 

--- a/src/components/orgs/orgList.vue
+++ b/src/components/orgs/orgList.vue
@@ -353,7 +353,7 @@ export default {
     height: 100vh;
 
     &__separator {
-      border: 1px solid $unnnic-color-neutral-soft;
+      border: 1px solid $unnnic-color-border-base;
       margin: $unnnic-spacing-stack-md 0 1rem 0;
     }
 
@@ -380,7 +380,7 @@ export default {
         font-weight: $unnnic-font-weight-regular;
         font-size: $unnnic-font-size-body-gt;
         line-height: $unnnic-font-size-title-sm + $unnnic-line-height-medium;
-        color: $unnnic-color-neutral-cloudy;
+        color: $unnnic-color-fg-base;
       }
 
       &__info {

--- a/src/components/orgs/orgRole.vue
+++ b/src/components/orgs/orgRole.vue
@@ -166,7 +166,7 @@ export default {
 
   &__action {
     &__button {
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
     }
   }
 
@@ -178,11 +178,11 @@ export default {
 
     &__name {
       font-weight: $unnnic-font-weight-bold;
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-fg-emphasized;
     }
 
     &__email {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-fg-base;
       white-space: nowrap;
       text-overflow: ellipsis;
     }
@@ -216,7 +216,7 @@ export default {
       margin: 0;
       line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
       font-size: $unnnic-font-size-body-md;
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
     }
   }
 }

--- a/src/components/projects/ProjectList.vue
+++ b/src/components/projects/ProjectList.vue
@@ -382,7 +382,7 @@ export default {
 
   &__create {
     padding: $unnnic-inset-md;
-    border: $unnnic-border-width-thinner solid $unnnic-color-border-base;
+    border: 1px solid $unnnic-color-border-base;
     color: $unnnic-color-fg-base;
     border-radius: $unnnic-border-radius-md;
     font-family: $unnnic-font-family-secondary;

--- a/src/components/users/UserListItem.vue
+++ b/src/components/users/UserListItem.vue
@@ -347,7 +347,7 @@ export default {
       overflow: hidden;
       text-overflow: ellipsis;
       font-weight: $unnnic-font-weight-bold;
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-fg-emphasized;
     }
 
     .email {
@@ -355,7 +355,7 @@ export default {
       overflow: hidden;
       text-overflow: ellipsis;
       font-weight: $unnnic-font-weight-regular;
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-fg-base;
     }
   }
 

--- a/src/modals/TrialPeriod.vue
+++ b/src/modals/TrialPeriod.vue
@@ -131,7 +131,7 @@ export default {
     font-size: $unnnic-font-size-title-sm;
     font-weight: $unnnic-font-weight-black;
     line-height: $unnnic-line-height-large + $unnnic-font-size-body-md;
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-fg-emphasized;
     margin: 0;
   }
 
@@ -139,7 +139,7 @@ export default {
     font-size: $unnnic-font-size-body-gt;
     font-weight: $unnnic-font-weight-regular;
     line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-fg-base;
     margin-top: $unnnic-spacing-xs;
   }
 }

--- a/src/views/ProjectHomeBlank/ChampionChatbot.vue
+++ b/src/views/ProjectHomeBlank/ChampionChatbot.vue
@@ -156,8 +156,8 @@ export default {
 
 <style lang="scss" scoped>
 $colors: (
-  'brand-weni-soft': $unnnic-color-brand-weni-soft,
-  'brand-weni-dark': $unnnic-color-brand-weni-dark,
+  'brand-weni-soft': $unnnic-color-teal-8,
+  'brand-weni-dark': $unnnic-color-teal-12,
 );
 
 .champion-chatbot {
@@ -165,7 +165,7 @@ $colors: (
   flex-direction: column;
   row-gap: $unnnic-spacing-stack-nano;
   padding: $unnnic-squish-nano;
-  background-color: $unnnic-color-background-sky;
+  background-color: $unnnic-color-bg-base-soft;
   border-radius: $unnnic-border-radius-md;
   height: 100%;
   box-sizing: border-box;
@@ -177,7 +177,7 @@ $colors: (
   font-weight: $unnnic-font-weight-bold;
   font-size: $unnnic-font-size-body-gt;
   line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-  color: $unnnic-color-neutral-darkest;
+  color: $unnnic-color-fg-emphasized;
 }
 
 .description {
@@ -185,7 +185,7 @@ $colors: (
   font-weight: $unnnic-font-weight-regular;
   font-size: $unnnic-font-size-title-sm;
   line-height: $unnnic-font-size-title-sm + $unnnic-line-height-md;
-  color: $unnnic-color-neutral-darkest;
+  color: $unnnic-color-fg-emphasized;
 
   :deep(b) {
     font-weight: $unnnic-font-weight-bold;
@@ -204,10 +204,10 @@ $colors: (
     display: flex;
     align-items: center;
     justify-content: center;
-    border: $unnnic-border-width-thinner solid $unnnic-color-neutral-cleanest;
+    border: 1px solid $unnnic-color-border-emphasized;
     box-sizing: border-box;
     border-radius: 50%;
-    background-color: $unnnic-color-background-snow;
+    background-color: $unnnic-color-bg-base;
 
     @each $name, $color in $colors {
       &.color-#{$name} {
@@ -223,7 +223,7 @@ $colors: (
 
   .level {
     height: 0.5rem;
-    background-color: $unnnic-color-neutral-cleanest;
+    background-color: $unnnic-color-gray-7;
     flex: 1;
     border-radius: $unnnic-border-radius-sm;
 

--- a/src/views/ProjectHomeBlank/QuickAccess.vue
+++ b/src/views/ProjectHomeBlank/QuickAccess.vue
@@ -12,8 +12,8 @@
       />
 
       <div class="options">
-        <div class="add-channel u bg-neutral-snow">
-          <div class="u font body-gt bold color-neutral-darkest">
+        <div class="add-channel u">
+          <div class="u font body-gt bold color-fg-emphasized">
             {{ $t('home.quick_access.add_channel.title') }}
           </div>
 
@@ -46,8 +46,8 @@
           </UnnnicButton>
         </div>
 
-        <div class="invite-member u bg-neutral-snow">
-          <div class="u font body-gt bold color-neutral-darkest">
+        <div class="invite-member u">
+          <div class="u font body-gt bold color-fg-emphasized">
             {{ $t('home.quick_access.invite_member.title') }}
           </div>
 
@@ -83,7 +83,7 @@
         :info="$t('home.quick_access.lastest_activities.info')"
       />
 
-      <div class="lastest-activities u bg-neutral-snow">
+      <div class="lastest-activities u">
         <div class="content">
           <section
             v-show="loading"
@@ -110,7 +110,7 @@
             :key="index"
           >
             <span
-              class="u font secondary body-md color-neutral-darkest"
+              class="u font secondary body-md color-fg-emphasized"
               v-html="
                 $t(
                   `home.quick_access.lastest_activities.actions.${activity.action}`,
@@ -119,9 +119,7 @@
               "
             ></span>
 
-            <span
-              class="u font secondary body-sm color-neutral-cloudy upper-case"
-            >
+            <span class="u font secondary body-sm color-fg-base upper-case">
               {{ fromNow(activity.created_at) }}
             </span>
           </div>
@@ -345,7 +343,8 @@ export default {
 
   .options > *,
   .lastest-activities {
-    box-shadow: $unnnic-shadow-level-separated;
+    background-color: $unnnic-color-bg-base;
+    box-shadow: $unnnic-shadow-1;
   }
 
   .lastest-activities {
@@ -358,7 +357,7 @@ export default {
     border-radius: $unnnic-border-radius-sm;
 
     :deep(.highlight) {
-      color: $unnnic-color-brand-weni-soft;
+      color: $unnnic-color-teal-8;
     }
 
     .content {

--- a/src/views/account.vue
+++ b/src/views/account.vue
@@ -802,8 +802,8 @@ export default {
 
 <style lang="scss">
 .weni-alert-button {
-  background-color: $unnnic-color-feedback-yellow;
-  color: $unnnic-color-neutral-snow;
+  background-color: $unnnic-color-bg-warning;
+  color: $unnnic-color-fg-inverted;
 }
 
 .weni-checkbox {
@@ -820,7 +820,7 @@ export default {
   }
 
   &__card {
-    border-right: 2px $unnnic-color-neutral-soft solid;
+    border-right: 2px $unnnic-color-border-base solid;
     padding-right: $unnnic-spacing-sm;
 
     &__item {
@@ -880,12 +880,12 @@ export default {
     &__checkbox {
       display: flex;
       margin-top: $unnnic-spacing-stack-md;
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
     }
   }
 
   &__danger {
-    color: $unnnic-color-feedback-red !important;
+    color: $unnnic-color-fg-critical !important;
   }
 
   &__header {
@@ -898,7 +898,7 @@ export default {
     align-items: center;
 
     button {
-      background-color: $unnnic-color-background-snow;
+      background-color: $unnnic-color-bg-base;
     }
 
     &__text {
@@ -913,19 +913,19 @@ export default {
       &__subtitle {
         font-family: $unnnic-font-family-secondary;
         font-size: $unnnic-font-size-body-lg;
-        color: $unnnic-color-neutral-dark;
+        color: $unnnic-color-fg-base;
       }
     }
 
     &__info {
       display: flex;
       align-items: center;
-      color: $unnnic-color-neutral-clean;
+      color: $unnnic-color-fg-base;
       font-size: $unnnic-font-size-body-sm;
       margin: $unnnic-spacing-stack-sm 0 0 0;
       &__separator {
         flex: 1;
-        border: 1px solid $unnnic-color-neutral-soft;
+        border: 1px solid $unnnic-color-border-base;
         margin-right: $unnnic-inline-nano;
 
         &__text {

--- a/src/views/billing/billing.vue
+++ b/src/views/billing/billing.vue
@@ -817,7 +817,7 @@ export default {
         display: flex;
 
         .title {
-          color: $unnnic-color-neutral-black;
+          color: $unnnic-color-fg-emphasized;
           font-family: $unnnic-font-family-primary;
           font-weight: $unnnic-font-weight-regular;
           font-size: $unnnic-font-size-title-lg;
@@ -830,7 +830,7 @@ export default {
         padding-left: 40px;
 
         .subtitle {
-          color: $unnnic-color-neutral-dark;
+          color: $unnnic-color-fg-base;
           font-family: $unnnic-font-family-secondary;
           font-weight: $unnnic-font-weight-regular;
           font-size: $unnnic-font-size-body-lg;
@@ -901,7 +901,7 @@ export default {
         font-weight: $unnnic-font-weight-regular;
         font-size: $unnnic-font-size-body-lg;
         line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
-        color: $unnnic-color-neutral-darkest;
+        color: $unnnic-color-fg-emphasized;
 
         .content {
           opacity: 0;
@@ -920,7 +920,7 @@ export default {
           backdrop-filter: blur(4px);
 
           .unnnic-button--tertiary.feedback-red {
-            color: $unnnic-color-feedback-red;
+            color: $unnnic-color-fg-critical;
           }
         }
 
@@ -931,7 +931,7 @@ export default {
         .description {
           font-size: $unnnic-font-size-body-gt;
           line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-          color: $unnnic-color-neutral-cloudy;
+          color: $unnnic-color-fg-base;
         }
 
         .header,
@@ -947,10 +947,10 @@ export default {
       }
 
       .card {
-        background-color: $unnnic-color-background-snow;
+        background-color: $unnnic-color-bg-base;
         border-radius: $unnnic-border-radius-md;
         padding: $unnnic-spacing-inset-md;
-        border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+        border: 1px solid $unnnic-color-border-base;
         height: 11rem;
         box-sizing: border-box;
 
@@ -974,7 +974,7 @@ export default {
               font-weight: $unnnic-font-weight-regular;
               font-size: $unnnic-font-size-body-lg;
               line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
-              color: $unnnic-color-neutral-cloudy;
+              color: $unnnic-color-fg-base;
             }
           }
         }
@@ -989,7 +989,7 @@ export default {
             font-weight: $unnnic-font-weight-black;
             font-size: $unnnic-font-size-title-md;
             line-height: $unnnic-font-size-title-md + $unnnic-line-height-md;
-            color: $unnnic-color-brand-sec-dark;
+            color: $unnnic-color-fg-emphasized;
           }
 
           .description {
@@ -997,7 +997,7 @@ export default {
             font-weight: $unnnic-font-weight-regular;
             font-size: $unnnic-font-size-body-lg;
             line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
-            color: $unnnic-color-neutral-cloudy;
+            color: $unnnic-color-fg-base;
           }
 
           .actions {
@@ -1010,7 +1010,7 @@ export default {
               flex: 1;
 
               &.danger {
-                color: $unnnic-color-feedback-red;
+                color: $unnnic-color-fg-critical;
               }
             }
           }
@@ -1030,7 +1030,7 @@ export default {
               padding: $unnnic-inset-nano;
               border-radius: $unnnic-border-radius-sm;
               background-color: rgba(
-                $unnnic-color-neutral-cloudy,
+                $unnnic-color-gray-11,
                 $unnnic-opacity-level-extra-light
               );
             }
@@ -1046,8 +1046,8 @@ export default {
                   font-size: $unnnic-font-size-title-sm;
                   line-height: $unnnic-font-size-title-sm +
                     $unnnic-line-height-md;
-                  color: $unnnic-color-neutral-black;
-                  margin-right: $unnnic-spacing-inline-nano;
+          color: $unnnic-color-fg-emphasized;
+          margin-right: $unnnic-spacing-inline-nano;
                 }
 
                 .strong {
@@ -1056,7 +1056,7 @@ export default {
                   font-size: $unnnic-font-size-title-md;
                   line-height: $unnnic-font-size-title-md +
                     $unnnic-line-height-md;
-                  color: $unnnic-color-brand-sec-dark;
+                  color: $unnnic-color-fg-emphasized;
                 }
               }
 
@@ -1065,7 +1065,7 @@ export default {
                 font-weight: $unnnic-font-weight-regular;
                 font-size: $unnnic-font-size-body-lg;
                 line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
-                color: $unnnic-color-neutral-cloudy;
+                color: $unnnic-color-fg-base;
               }
             }
           }
@@ -1083,7 +1083,7 @@ export default {
   }
   &__title {
     font-family: $unnnic-font-family-primary;
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-fg-emphasized;
     font-weight: $unnnic-font-weight-regular;
     margin: 0;
     font-size: $unnnic-font-size-title-sm;
@@ -1094,7 +1094,7 @@ export default {
     cursor: pointer;
     text-decoration: underline;
     font-size: $unnnic-font-size-body-gt;
-    color: $unnnic-color-neutral-dark;
+    color: $unnnic-color-fg-base;
   }
 }
 .unnnic-grid-lg {

--- a/src/views/billing/billingContainer.vue
+++ b/src/views/billing/billingContainer.vue
@@ -5,12 +5,12 @@
       class="header grid"
     >
       <div
-        class="title unnnic-font secondary title-md black color-brand-sec-dark"
+        class="title unnnic-font secondary title-md black color-fg-emphasized"
       >
         {{ title }}
       </div>
 
-      <div class="subtitle unnnic-font secondary body-lg color-neutral-dark">
+      <div class="subtitle unnnic-font secondary body-lg color-fg-base">
         <span v-html="subtitle" />
         <slot name="after-subtitle" />
       </div>

--- a/src/views/billing/plans/BillingPlans.vue
+++ b/src/views/billing/plans/BillingPlans.vue
@@ -47,7 +47,7 @@
                 :text="$t('billing.card.payment_day', { date: paymentDay })"
               />
 
-              <p class="unnnic-font secondary body-gt color-neutral-cloudy">
+              <p class="unnnic-font secondary body-gt color-fg-base">
                 {{ $t('billing.card.security_payment') }}
               </p>
             </template>
@@ -471,9 +471,9 @@ export default {
 
 :deep {
   .StripeElement {
-    border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+    border: 1px solid $unnnic-color-border-base;
     border-radius: $unnnic-border-radius-sm;
-    background-color: $unnnic-color-neutral-snow;
+    background-color: $unnnic-color-bg-base;
     padding: $unnnic-squish-xs;
     cursor: text;
 
@@ -482,11 +482,11 @@ export default {
     }
 
     &.StripeElement--focus {
-      border-color: $unnnic-color-neutral-cleanest;
+      border-color: $unnnic-color-border-emphasized;
     }
 
     &.StripeElement--invalid {
-      border-color: $unnnic-color-feedback-red;
+      border-color: $unnnic-color-border-critical;
     }
   }
 }

--- a/src/views/billing/tabs/activeContacts.vue
+++ b/src/views/billing/tabs/activeContacts.vue
@@ -441,7 +441,7 @@ export default {
     font-weight: $unnnic-font-weight-regular;
     font-size: $unnnic-font-size-body-gt;
     line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-fg-emphasized;
     margin-right: $unnnic-spacing-inline-sm;
   }
 }

--- a/src/views/billing/tabs/invoices.vue
+++ b/src/views/billing/tabs/invoices.vue
@@ -667,7 +667,7 @@ export default {
     font-weight: $unnnic-font-weight-regular;
     font-size: $unnnic-font-size-body-gt;
     line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-fg-emphasized;
     margin-right: $unnnic-spacing-inline-sm;
   }
 }
@@ -684,7 +684,7 @@ export default {
   }
 
   .title {
-    color: $unnnic-color-neutral-black;
+    color: $unnnic-color-fg-emphasized;
     font-family: $unnnic-font-family-secondary;
     font-weight: $unnnic-font-weight-bold;
     font-size: $unnnic-font-size-body-lg;
@@ -693,7 +693,7 @@ export default {
   }
 
   .description {
-    color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-fg-base;
     font-family: $unnnic-font-family-secondary;
     font-weight: $unnnic-font-weight-regular;
     font-size: $unnnic-font-size-body-gt;

--- a/src/views/home.vue
+++ b/src/views/home.vue
@@ -162,7 +162,7 @@ export default {
 
 <style lang="scss" scoped>
 .weni-home {
-  background-color: $unnnic-color-background-snow;
+  background-color: $unnnic-color-bg-base;
   width: 100%;
   box-sizing: border-box;
   padding-top: $unnnic-spacing-stack-md;
@@ -173,7 +173,7 @@ export default {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   margin: $unnnic-spacing-md;
-  box-shadow: $unnnic-shadow-level-separated;
+  box-shadow: $unnnic-shadow-1;
 }
 
 .discover-title {
@@ -189,7 +189,7 @@ export default {
   font-size: $unnnic-font-size-title-md;
   font-weight: $unnnic-font-weight-bold;
   font-family: $unnnic-font-family-primary;
-  color: $unnnic-color-neutral-darkest;
+  color: $unnnic-color-fg-emphasized;
   margin: 0 !important;
   padding-bottom: $unnnic-spacing-xs;
   padding-top: $unnnic-spacing-md;
@@ -198,7 +198,7 @@ export default {
 .discover-title-description {
   font-family: $unnnic-font-family-secondary;
   font-size: $unnnic-font-size-body-lg;
-  color: $unnnic-color-neutral-dark;
+  color: $unnnic-color-fg-base;
   line-height: 1.5rem;
   margin: 0 !important;
   padding-bottom: $unnnic-spacing-md;

--- a/src/views/loadings/billing.vue
+++ b/src/views/loadings/billing.vue
@@ -54,7 +54,7 @@
 
   .tabs {
     padding-bottom: 1rem;
-    border-bottom: 1px solid $unnnic-color-neutral-soft;
+    border-bottom: 1px solid $unnnic-color-border-base;
     display: flex;
     column-gap: 1rem;
   }

--- a/src/views/not-found.vue
+++ b/src/views/not-found.vue
@@ -120,7 +120,7 @@ export default {
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-h4;
       line-height: $unnnic-font-size-h4 + $unnnic-line-height-md;
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-fg-emphasized;
       margin-bottom: $unnnic-spacing-stack-sm;
 
       &.organization-require-two-factor {
@@ -134,7 +134,7 @@ export default {
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-body-lg;
       line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-fg-emphasized;
       margin-bottom: $unnnic-spacing-stack-lg;
     }
 
@@ -143,7 +143,7 @@ export default {
       font-weight: $unnnic-font-weight-bold;
       font-size: $unnnic-font-size-body-lg;
       line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-fg-emphasized;
       text-decoration: underline;
     }
   }
@@ -171,7 +171,7 @@ export default {
     .complete {
       width: auto;
       flex: 1;
-      background-color: $unnnic-color-neutral-darkest;
+      background-color: $unnnic-color-gray-12;
     }
 
     .spacer {

--- a/src/views/org/orgs.vue
+++ b/src/views/org/orgs.vue
@@ -151,8 +151,8 @@ hr {
   width: 100%;
   margin-block: $unnnic-spacing-xl;
   border-width: 0;
-  margin-block-start: $unnnic-spacing-xl - $unnnic-border-width-thinner;
-  border-top: $unnnic-border-width-thinner solid $unnnic-color-border-base;
+  margin-block-start: $unnnic-spacing-xl - 1px;
+  border-top: 1px solid $unnnic-color-border-base;
 }
 
 .weni-orgs {
@@ -201,7 +201,7 @@ hr {
     box-sizing: border-box;
     padding: 0 12.88%;
     padding-bottom: $unnnic-spacing-stack-xl - ($unnnic-border-width-thick * 2);
-    border-bottom: $unnnic-border-width-thick * 2 solid $unnnic-color-brand-weni;
+    border-bottom: $unnnic-border-width-thick * 2 solid $unnnic-color-teal-8;
   }
 
   &__right {
@@ -255,12 +255,12 @@ hr {
     }
 
     &::-webkit-scrollbar-thumb {
-      background: $unnnic-color-neutral-clean;
+      background: $unnnic-color-gray-11;
       border-radius: $unnnic-border-radius-pill;
     }
 
     &::-webkit-scrollbar-track {
-      background: $unnnic-color-neutral-soft;
+      background: $unnnic-color-gray-3;
       border-radius: $unnnic-border-radius-pill;
     }
   }
@@ -286,7 +286,7 @@ hr {
 
       h1 {
         font-family: $unnnic-font-family-primary;
-        color: $unnnic-color-neutral-darkest;
+        color: $unnnic-color-fg-emphasized;
         font-weight: $unnnic-font-weight-bold;
         font-size: $unnnic-font-size-title-lg;
         line-height: $unnnic-font-size-title-lg + $unnnic-line-height-md;
@@ -296,7 +296,7 @@ hr {
 
       p {
         font-family: $unnnic-font-family-secondary;
-        color: $unnnic-color-neutral-dark;
+        color: $unnnic-color-fg-base;
         font-weight: $unnnic-font-weight-regular;
         font-size: $unnnic-font-size-body-lg;
         line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;

--- a/src/views/privacy-policy.vue
+++ b/src/views/privacy-policy.vue
@@ -88,7 +88,7 @@ export default {
 .privacy-policy {
   min-height: 100vh;
   box-sizing: border-box;
-  border-bottom: $unnnic-border-width-thick * 2 solid $unnnic-color-brand-weni;
+  border-bottom: $unnnic-border-width-thick * 2 solid $unnnic-color-teal-8;
 
   .language-select {
     width: 12.5rem;
@@ -113,7 +113,7 @@ export default {
     margin-bottom: $unnnic-spacing-stack-lg;
 
     .title {
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-fg-emphasized;
       font-family: $unnnic-font-family-primary;
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-title-lg;
@@ -122,7 +122,7 @@ export default {
     }
 
     .description {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-fg-base;
       font-family: $unnnic-font-family-secondary;
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-body-lg;
@@ -132,7 +132,7 @@ export default {
 
   .content {
     .warning {
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
       font-family: $unnnic-font-family-secondary;
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-body-lg;
@@ -140,13 +140,13 @@ export default {
       text-align: justify;
 
       padding: $unnnic-inset-lg;
-      background-color: $unnnic-color-background-carpet;
+      background-color: $unnnic-color-bg-base-soft;
       border-radius: $unnnic-border-radius-md;
       margin-bottom: $unnnic-spacing-stack-md;
     }
 
     a {
-      color: $unnnic-color-brand-weni;
+      color: $unnnic-color-fg-accent;
       text-decoration: none;
     }
 

--- a/src/views/projects/container.vue
+++ b/src/views/projects/container.vue
@@ -34,7 +34,7 @@ export default {
   .container {
     padding: $unnnic-spacing-stack-xl 12.88%;
     flex: 1;
-    border-bottom: $unnnic-border-width-thick * 2 solid $unnnic-color-brand-weni;
+    border-bottom: $unnnic-border-width-thick * 2 solid $unnnic-color-teal-8;
 
     @media only screen and (max-width: 60rem) {
       padding: $unnnic-spacing-stack-xl $unnnic-spacing-inline-sm;

--- a/src/views/projects/projects.vue
+++ b/src/views/projects/projects.vue
@@ -276,7 +276,7 @@ export default {
     margin-top: $unnnic-spacing-stack-md;
     padding-bottom: $unnnic-spacing-stack-lg;
     display: flex;
-    border-bottom: 0.5rem solid $unnnic-color-brand-weni;
+    border-bottom: 0.5rem solid $unnnic-color-teal-8;
 
     .content {
       margin: 0 12.88%;
@@ -292,7 +292,7 @@ export default {
         display: flex;
 
         .title {
-          color: $unnnic-color-neutral-black;
+          color: $unnnic-color-fg-emphasized;
           font-family: $unnnic-font-family-primary;
           font-weight: $unnnic-font-weight-regular;
           font-size: $unnnic-font-size-title-lg;
@@ -304,7 +304,7 @@ export default {
         grid-row-start: 2;
 
         .subtitle {
-          color: $unnnic-color-neutral-dark;
+          color: $unnnic-color-fg-base;
           font-family: $unnnic-font-family-secondary;
           font-weight: $unnnic-font-weight-regular;
           font-size: $unnnic-font-size-body-lg;
@@ -385,7 +385,7 @@ export default {
 
   .line {
     height: 1px;
-    background-color: $unnnic-color-neutral-soft;
+    background-color: $unnnic-color-border-base;
     margin: $unnnic-spacing-stack-md 0;
   }
 

--- a/src/views/projects/templates/setup.vue
+++ b/src/views/projects/templates/setup.vue
@@ -3,7 +3,7 @@
   <div class="setup">
     <main>
       <header v-if="!form">
-        <div class="unnnic-font secondary title-sm bold color-neutral-darkest">
+        <div class="unnnic-font secondary title-sm bold color-fg-emphasized">
           {{
             $t('projects.create.format.setup.title', {
               name: template.name,
@@ -11,7 +11,7 @@
           }}
         </div>
 
-        <div class="unnnic-font secondary body-lg color-neutral-cloudy">
+        <div class="unnnic-font secondary body-lg color-fg-base">
           {{ template.description }}
         </div>
       </header>
@@ -110,7 +110,7 @@
     >
       <img :src="template.setup.image.src" />
 
-      <div class="unnnic-font secondary body-sm color-neutral-cloudy">
+      <div class="unnnic-font secondary body-sm color-fg-base">
         {{ template.setup.image.description }}
       </div>
     </div>
@@ -336,7 +336,7 @@ export default {
   .image {
     width: 27rem;
     padding: $unnnic-spacing-inset-xs;
-    border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+    border: 1px solid $unnnic-color-border-base;
     border-radius: $unnnic-border-radius-sm;
     display: flex;
     flex-direction: column;

--- a/src/views/register/Navigator.vue
+++ b/src/views/register/Navigator.vue
@@ -65,7 +65,7 @@ export default {
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-body-md;
       line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
-      color: $unnnic-color-neutral-clean;
+      color: $unnnic-color-fg-base;
     }
 
     @media screen and (max-width: 480px) {

--- a/src/views/register/forms/ModalAddContent.vue
+++ b/src/views/register/forms/ModalAddContent.vue
@@ -193,8 +193,8 @@ export default {
   }
 
   .sites-area {
-    padding: $unnnic-space-4 - $unnnic-border-width-thinner;
-    border: $unnnic-border-width-thinner solid $unnnic-color-border-muted;
+    padding: $unnnic-space-4 - 1px;
+    border: 1px solid $unnnic-color-border-muted;
     border-radius: $unnnic-radius-2;
 
     .form-element + .form-element,

--- a/src/views/register/forms/TemplateGallery.vue
+++ b/src/views/register/forms/TemplateGallery.vue
@@ -464,7 +464,7 @@ export default {
   margin: 0;
   margin-bottom: $unnnic-spacing-sm;
 
-  color: $unnnic-color-neutral-cloudy;
+  color: $unnnic-color-fg-base;
   font-family: $unnnic-font-family-secondary;
   font-weight: $unnnic-font-weight-regular;
   font-size: $unnnic-font-size-body-gt;
@@ -495,7 +495,7 @@ export default {
     font-weight: $unnnic-font-weight-bold;
     font-size: $unnnic-font-size-body-md;
     line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-dark;
+    color: $unnnic-color-fg-base;
   }
 
   .category {
@@ -530,9 +530,9 @@ export default {
     flex-direction: column;
     border-radius: $unnnic-border-radius-md;
     outline-style: solid;
-    outline-color: $unnnic-color-neutral-cleanest;
-    outline-width: $unnnic-border-width-thinner;
-    outline-offset: -$unnnic-border-width-thinner;
+    outline-color: $unnnic-color-border-emphasized;
+    outline-width: 1px;
+    outline-offset: -1px;
     padding: $unnnic-spacing-sm;
     cursor: pointer;
     user-select: none;
@@ -546,7 +546,7 @@ export default {
       aspect-ratio: 245 / 100;
       object-fit: cover;
       border-radius: $unnnic-border-radius-sm;
-      background-color: $unnnic-color-neutral-light;
+      background-color: $unnnic-color-bg-muted;
     }
 
     &__title {
@@ -554,7 +554,7 @@ export default {
       font-weight: $unnnic-font-weight-bold;
       font-size: $unnnic-font-size-body-lg;
       line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-fg-base;
 
       margin-top: $unnnic-spacing-sm;
     }
@@ -581,7 +581,7 @@ export default {
     font-weight: $unnnic-font-weight-regular;
     font-size: $unnnic-font-size-body-gt;
     line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-dark;
+    color: $unnnic-color-fg-base;
   }
 
   &__description {
@@ -634,7 +634,7 @@ export default {
   &__observation {
     padding: $unnnic-spacing-xs $unnnic-spacing-ant;
     border-radius: $unnnic-border-radius-md;
-    background-color: $unnnic-color-neutral-soft;
+    background-color: $unnnic-color-bg-muted;
     display: flex;
     flex-direction: column;
     row-gap: $unnnic-spacing-nano;
@@ -645,7 +645,7 @@ export default {
       font-weight: $unnnic-font-weight-regular;
       font-size: $unnnic-font-size-body-md;
       line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-fg-base;
     }
 
     :deep(b),
@@ -670,9 +670,9 @@ export default {
 
 .field-content {
   display: flex;
-  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+  border: 1px solid $unnnic-color-border-base;
   border-radius: $unnnic-border-radius-sm;
-  padding: $unnnic-spacing-ant - $unnnic-border-width-thinner;
+  padding: $unnnic-spacing-ant - 1px;
 
   > * {
     flex: 1;

--- a/src/views/register/index.vue
+++ b/src/views/register/index.vue
@@ -929,7 +929,7 @@ export default {
     font-weight: $unnnic-font-weight-bold;
     font-size: $unnnic-font-size-title-md;
     line-height: $unnnic-font-size-title-md + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-fg-emphasized;
     margin-bottom: $unnnic-spacing-md;
 
     :deep(.highlighted) {
@@ -942,7 +942,7 @@ export default {
     font-weight: $unnnic-font-weight-regular;
     font-size: $unnnic-font-size-body-gt;
     line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-fg-base;
   }
 
   .title + .description {

--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -325,8 +325,8 @@ export default {
   }
 
   .separator {
-    width: $unnnic-border-width-thinner;
-    background-color: $unnnic-color-neutral-soft;
+    width: 1px;
+    background-color: $unnnic-color-border-base;
   }
 
   .page {


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The design system token naming convention has been updated. This change migrates all SCSS color and shadow variable references across the codebase to align with the new semantic token system introduced in the updated version of the Unnnic design library.

### Summary of Changes
- Replaced legacy neutral color tokens (e.g., `$unnnic-color-neutral-dark`, `$unnnic-color-neutral-snow`, `$unnnic-color-neutral-darkest`) with new semantic foreground and background tokens (e.g., `$unnnic-color-fg-base`, `$unnnic-color-bg-base`, `$unnnic-color-fg-emphasized`).
- Replaced legacy background tokens (e.g., `$unnnic-color-background-snow`, `$unnnic-color-background-carpet`, `$unnnic-color-background-sky`) with new `$unnnic-color-bg-*` equivalents.
- Replaced legacy feedback color tokens (e.g., `$unnnic-color-feedback-red`, `$unnnic-color-feedback-yellow`, `$unnnic-color-feedback-blue`) with semantic tokens (`$unnnic-color-fg-critical`, `$unnnic-color-fg-warning`, `$unnnic-color-fg-info`).
- Replaced legacy shadow tokens (`$unnnic-shadow-level-near`, `$unnnic-shadow-level-separated`, `$unnnic-shadow-level-far`) with the unified `$unnnic-shadow-1`.
- Replaced `$unnnic-border-width-thinner` with the literal value `1px` where the variable was used solely for border widths.
- Replaced legacy brand and auxiliary color tokens (e.g., `$unnnic-color-brand-weni`, `$unnnic-color-aux-purple-500`) with their new palette equivalents (e.g., `$unnnic-color-teal-8`, `$unnnic-color-purple-7`).
- Removed a commented-out dark theme color inversion block from `unnnic-styles.scss` that was no longer in use.