### PR TITLE
feat: enhance domain input validation and UX in SSO settings

### DIFF
--- a/src/components/common/RightBar/updateOrg.vue
+++ b/src/components/common/RightBar/updateOrg.vue
@@ -104,7 +104,13 @@
               class="weni-update-org__sso-field"
               :label="$t('orgs.sso.allowed_domains')"
               :placeholder="$t('orgs.sso.allowed_domains_placeholder')"
-              @keydown.enter="addDomain"
+              :iconRight="
+                ssoForm.domainInput.trim() ? 'keyboard-return-1' : undefined
+              "
+              iconRightClickable
+              :errors="domainInputError"
+              @icon-right-click="addDomain"
+              @keydown="onDomainKeydown"
             />
 
             <div
@@ -153,6 +159,9 @@ import Unnnic from '@weni/unnnic-system';
 import _ from 'lodash';
 
 const SSO_PROVIDERS = ['google', 'microsoft'];
+
+const EMAIL_DOMAIN_PATTERN =
+  /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i;
 
 export default {
   name: 'UpdateOrg',
@@ -243,7 +252,18 @@ export default {
       );
     },
 
+    domainInputError() {
+      const value = this.ssoForm.domainInput.trim();
+      if (!value) return false;
+
+      return this._getDomainValidationError(value) || false;
+    },
+
     isSaveDisabled() {
+      if (this.domainInputError) {
+        return true;
+      }
+
       if (this.ssoDirty && !this.ssoValid) {
         return true;
       }
@@ -365,17 +385,37 @@ export default {
       }
     },
 
-    addDomain() {
-      const domain = this.ssoForm.domainInput
-        .trim()
-        .replace(/^@/, '')
-        .toLowerCase();
+    onDomainKeydown(event) {
+      if (!['Enter', ' ', ','].includes(event.key)) return;
 
-      if (domain && !this.ssoForm.domains.includes(domain)) {
+      event.preventDefault();
+      this.addDomain();
+    },
+
+    addDomain() {
+      const raw = this.ssoForm.domainInput.trim();
+      if (!raw) return;
+
+      if (this._getDomainValidationError(raw)) return;
+
+      const domain = raw.toLowerCase();
+      if (!this.ssoForm.domains.includes(domain)) {
         this.ssoForm.domains.push(domain);
       }
 
       this.ssoForm.domainInput = '';
+    },
+
+    _getDomainValidationError(value) {
+      if (value.includes('@') || value.includes('://') || /\s/.test(value)) {
+        return this.$t('orgs.sso.invalid_domain');
+      }
+
+      if (!EMAIL_DOMAIN_PATTERN.test(value)) {
+        return this.$t('orgs.sso.invalid_domain');
+      }
+
+      return null;
     },
 
     removeDomain(domain) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -674,6 +674,7 @@
       "description": "Require all organization members to sign in exclusively through Single Sign-On. Users who currently access the platform with a password will lose that access and must authenticate through your identity provider.",
       "enable": "Enable mandatory SSO",
       "helper": "When enabled, password-based login will be disabled for all users in this organization.",
+      "invalid_domain": "Enter a domain like yourcompany.com without @",
       "lockout_error": {
         "description": "Make sure at least one admin in your organization has SSO access before enabling this setting.",
         "title": "SSO login required for at least one admin"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -674,6 +674,7 @@
       "description": "Exige que todos los miembros de la organización inicien sesión exclusivamente mediante Single Sign-On. Quienes acceden a la plataforma con contraseña perderán ese acceso y deberán autenticarse mediante tu proveedor de identidad.",
       "enable": "Habilitar SSO obligatorio",
       "helper": "Cuando está habilitado, el inicio de sesión con contraseña se desactiva para todos los usuarios de esta organización.",
+      "invalid_domain": "Ingresa un dominio como tuempresa.com sin @",
       "lockout_error": {
         "description": "Asegúrate de que al menos un administrador de tu organización tenga acceso mediante SSO antes de habilitar esta configuración.",
         "title": "Inicio de sesión SSO obligatorio para al menos un administrador"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -674,6 +674,7 @@
       "description": "Exija que todos os membros da organização façam login exclusivamente por Single Sign-On. Quem acessa a plataforma com senha perderá esse acesso e precisará se autenticar pelo seu provedor de identidade.",
       "enable": "Habilitar SSO obrigatório",
       "helper": "Quando habilitado, o login por senha será desativado para todos os usuários desta organização.",
+      "invalid_domain": "Informe um domínio como suaempresa.com sem @",
       "lockout_error": {
         "description": "Garanta que pelo menos um administrador da sua organização tenha acesso via SSO antes de habilitar esta configuração.",
         "title": "Login SSO obrigatório para pelo menos um administrador"

--- a/tests/unit/unit/components/common/RightBar/UpdateOrgSSO.spec.js
+++ b/tests/unit/unit/components/common/RightBar/UpdateOrgSSO.spec.js
@@ -99,14 +99,27 @@ describe('UpdateOrg.vue - SSO settings', () => {
   });
 
   describe('addDomain', () => {
-    it('normalizes the value, strips a leading @ and clears the input', () => {
+    it('normalizes valid domains to lowercase and clears the input', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domainInput = '  Acme.COM ';
+      wrapper.vm.addDomain();
+
+      expect(wrapper.vm.ssoForm.domains).toEqual(['acme.com']);
+      expect(wrapper.vm.ssoForm.domainInput).toBe('');
+    });
+
+    it('rejects domains with @ and keeps the input', () => {
       const wrapper = mountComponent(buildOrg());
 
       wrapper.vm.ssoForm.domainInput = '  @Acme.COM ';
       wrapper.vm.addDomain();
 
-      expect(wrapper.vm.ssoForm.domains).toEqual(['acme.com']);
-      expect(wrapper.vm.ssoForm.domainInput).toBe('');
+      expect(wrapper.vm.ssoForm.domains).toEqual([]);
+      expect(wrapper.vm.ssoForm.domainInput).toBe('  @Acme.COM ');
+      expect(wrapper.vm.domainInputError).toBe(
+        wrapper.vm.$t('orgs.sso.invalid_domain'),
+      );
     });
 
     it('ignores empty values and duplicates', () => {
@@ -120,6 +133,132 @@ describe('UpdateOrg.vue - SSO settings', () => {
       wrapper.vm.addDomain();
 
       expect(wrapper.vm.ssoForm.domains).toEqual(['acme.com']);
+    });
+  });
+
+  describe('onDomainKeydown', () => {
+    it('adds the domain on Enter, space, and comma', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      ['Enter', ' ', ','].forEach((key) => {
+        wrapper.vm.ssoForm.domainInput = 'acme.com';
+        wrapper.vm.onDomainKeydown({ key, preventDefault: vi.fn() });
+
+        expect(wrapper.vm.ssoForm.domains).toContain('acme.com');
+        expect(wrapper.vm.ssoForm.domainInput).toBe('');
+      });
+
+      expect(wrapper.vm.ssoForm.domains).toEqual(['acme.com']);
+    });
+
+    it('calls addDomain on Enter, space, and comma', () => {
+      const wrapper = mountComponent(buildOrg());
+      const addDomainSpy = vi.spyOn(wrapper.vm, 'addDomain');
+
+      wrapper.vm.ssoForm.domainInput = 'acme.com';
+
+      ['Enter', ' ', ','].forEach((key) => {
+        const event = { key, preventDefault: vi.fn() };
+        wrapper.vm.onDomainKeydown(event);
+        expect(event.preventDefault).toHaveBeenCalled();
+      });
+
+      expect(addDomainSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('does nothing for other keys', () => {
+      const wrapper = mountComponent(buildOrg());
+      const addDomainSpy = vi.spyOn(wrapper.vm, 'addDomain');
+      const event = { key: 'a', preventDefault: vi.fn() };
+
+      wrapper.vm.onDomainKeydown(event);
+
+      expect(addDomainSpy).not.toHaveBeenCalled();
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('does not add a domain on space when the input is empty', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.onDomainKeydown({ key: ' ', preventDefault: vi.fn() });
+
+      expect(wrapper.vm.ssoForm.domains).toEqual([]);
+    });
+  });
+
+  describe('domain validation', () => {
+    it('adds gmail.com and clears the input', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domainInput = 'gmail.com';
+      wrapper.vm.addDomain();
+
+      expect(wrapper.vm.ssoForm.domains).toEqual(['gmail.com']);
+      expect(wrapper.vm.ssoForm.domainInput).toBe('');
+    });
+
+    it('rejects @gmail.com', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domainInput = '@gmail.com';
+      wrapper.vm.addDomain();
+
+      expect(wrapper.vm.ssoForm.domains).toEqual([]);
+      expect(wrapper.vm.ssoForm.domainInput).toBe('@gmail.com');
+      expect(wrapper.vm.domainInputError).toBe(
+        wrapper.vm.$t('orgs.sso.invalid_domain'),
+      );
+    });
+
+    it('rejects full email addresses', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domainInput = 'user@gmail.com';
+      wrapper.vm.addDomain();
+
+      expect(wrapper.vm.ssoForm.domains).toEqual([]);
+      expect(wrapper.vm.domainInputError).toBe(
+        wrapper.vm.$t('orgs.sso.invalid_domain'),
+      );
+    });
+
+    it('rejects domains without a TLD', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domainInput = 'gmail';
+      wrapper.vm.addDomain();
+
+      expect(wrapper.vm.ssoForm.domains).toEqual([]);
+      expect(wrapper.vm.domainInputError).toBe(
+        wrapper.vm.$t('orgs.sso.invalid_domain'),
+      );
+    });
+
+    it('returns no error when the input is empty', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      expect(wrapper.vm.domainInputError).toBe(false);
+    });
+  });
+
+  describe('domain input UX', () => {
+    it('adds a domain when addDomain is triggered from the icon handler', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domainInput = 'acme.com';
+      wrapper.vm.addDomain();
+
+      expect(wrapper.vm.ssoForm.domains).toEqual(['acme.com']);
+      expect(wrapper.vm.ssoForm.domainInput).toBe('');
+    });
+
+    it('accepts multi-level domains', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domainInput = 'sub.domain.co.uk';
+      wrapper.vm.addDomain();
+
+      expect(wrapper.vm.ssoForm.domains).toEqual(['sub.domain.co.uk']);
     });
   });
 
@@ -191,6 +330,15 @@ describe('UpdateOrg.vue - SSO settings', () => {
       wrapper.vm.enable2FA = true;
 
       expect(wrapper.vm.isSaveDisabled).toBe(false);
+    });
+
+    it('is disabled when there is invalid uncommitted domain input', () => {
+      const wrapper = mountComponent(buildOrg());
+
+      wrapper.vm.ssoForm.domainInput = '@gmail.com';
+
+      expect(wrapper.vm.domainInputError).toBeTruthy();
+      expect(wrapper.vm.isSaveDisabled).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The SSO allowed domains input previously accepted any value, including full email addresses (e.g. `user@gmail.com`), bare `@domain.com` entries, and strings without a valid TLD. This could lead to invalid domain entries being saved. Domain input also only triggered on `Enter`, missing common delimiter patterns users might expect.

### Summary of Changes
- Added a regex-based domain validation (`EMAIL_DOMAIN_PATTERN`) that enforces a proper domain format (e.g. `yourcompany.com`), rejecting full email addresses, `@`-prefixed values, URLs with `://`, whitespace, and domains without a TLD.
- Introduced a `domainInputError` computed property that surfaces an inline validation error on the input field when the current value is invalid.
- The save button is now disabled when there is invalid uncommitted domain input.
- Replaced the `@keydown.enter` listener with an `onDomainKeydown` handler that triggers `addDomain` on `Enter`, `Space`, and `,` keys.
- Added a clickable right-side icon (`keyboard-return-1`) to the domain input that appears when there is a non-empty value, allowing users to confirm a domain via click.
- Added the `orgs.sso.invalid_domain` error message to the English, Spanish, and Brazilian Portuguese locale files.
- Added unit tests covering valid domain acceptance, rejection of `@`-prefixed and full email inputs, domains without a TLD, keydown handling, multi-level domains, and the save button disabled state when invalid input is present.