### PR TITLE
fix: update invalid domain error message format in SSO settings for English, Spanish, and Portuguese locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.37.1] - 2026-06-29
+
+### Changed
+
+- fix: update invalid domain error message format in SSO settings
+
 ## [2.37.0] - 2026-06-29
 
 ### Changed

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -674,7 +674,7 @@
       "description": "Require all organization members to sign in exclusively through Single Sign-On. Users who currently access the platform with a password will lose that access and must authenticate through your identity provider.",
       "enable": "Enable mandatory SSO",
       "helper": "When enabled, password-based login will be disabled for all users in this organization.",
-      "invalid_domain": "Enter a domain like yourcompany.com without @",
+      "invalid_domain": "Enter a domain like yourcompany.com without {'@'}",
       "lockout_error": {
         "description": "Make sure at least one admin in your organization has SSO access before enabling this setting.",
         "title": "SSO login required for at least one admin"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -674,7 +674,7 @@
       "description": "Exige que todos los miembros de la organización inicien sesión exclusivamente mediante Single Sign-On. Quienes acceden a la plataforma con contraseña perderán ese acceso y deberán autenticarse mediante tu proveedor de identidad.",
       "enable": "Habilitar SSO obligatorio",
       "helper": "Cuando está habilitado, el inicio de sesión con contraseña se desactiva para todos los usuarios de esta organización.",
-      "invalid_domain": "Ingresa un dominio como tuempresa.com sin @",
+      "invalid_domain": "Ingresa un dominio como tuempresa.com sin {'@'}",
       "lockout_error": {
         "description": "Asegúrate de que al menos un administrador de tu organización tenga acceso mediante SSO antes de habilitar esta configuración.",
         "title": "Inicio de sesión SSO obligatorio para al menos un administrador"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -674,7 +674,7 @@
       "description": "Exija que todos os membros da organização façam login exclusivamente por Single Sign-On. Quem acessa a plataforma com senha perderá esse acesso e precisará se autenticar pelo seu provedor de identidade.",
       "enable": "Habilitar SSO obrigatório",
       "helper": "Quando habilitado, o login por senha será desativado para todos os usuários desta organização.",
-      "invalid_domain": "Informe um domínio como suaempresa.com sem @",
+      "invalid_domain": "Informe um domínio como suaempresa.com sem {'@'}",
       "lockout_error": {
         "description": "Garanta que pelo menos um administrador da sua organização tenha acesso via SSO antes de habilitar esta configuração.",
         "title": "Login SSO obrigatório para pelo menos um administrador"


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The `invalid_domain` error message in SSO settings was rendering the `@` symbol incorrectly due to Vue I18n's interpolation syntax. The `@` character has special meaning in Vue I18n and needed to be escaped to display as a literal character.

### Summary of Changes
The `invalid_domain` locale string in the English, Spanish, and Portuguese (Brazil) translations was updated to wrap the `@` symbol with `{'@'}` to prevent Vue I18n from interpreting it as a linked message reference, ensuring the character renders correctly in the UI.