### PR TITLE
feat: Add Flows module to marketing role sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.39.0] - 2026-07-08
+
+### Changed
+
+- feat: Add Flows module to marketing role sidebar
+
 ## [2.38.0] - 2026-07-08
 
 ### Changed

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -348,6 +348,7 @@ const options = computed(() => {
   if (isRoleMarketing.value) {
     return [
       { items: [modules.insights] },
+      { items: [modules.push] },
       { items: [modules.studio, modules.bulkSend].filter(Boolean) },
     ];
   }

--- a/tests/unit/unit/components/Sidebar/Sidebar.spec.js
+++ b/tests/unit/unit/components/Sidebar/Sidebar.spec.js
@@ -227,11 +227,11 @@ describe('Sidebar.vue', () => {
       wrapper = setup();
     });
 
-    it('should show limited sidebar options for marketing role (4 options: project selector, insights, studio, bulk send)', () => {
+    it('should show limited sidebar options for marketing role (project selector, insights, flows, studio, bulk send)', () => {
       const sidebarOptions = wrapper.findAllComponents(elements.sidebarOption);
 
-      // Marketing role should only see: project dropdown + insights + studio + bulkSend + expand/collapse
-      expect(sidebarOptions.length).toBe(5);
+      // Marketing role should only see: project dropdown + insights + push + studio + bulkSend + expand/collapse
+      expect(sidebarOptions.length).toBe(6);
     });
 
     it('should include Analytics option', () => {
@@ -247,6 +247,19 @@ describe('Sidebar.vue', () => {
       );
     });
 
+    it('should include Automation flow option', () => {
+      const sidebarOptions = wrapper.findAllComponents(elements.sidebarOption);
+      const props = sidebarOptions.map((option) => option.props());
+
+      expect(props).toContainEqual(
+        expect.objectContaining({
+          option: expect.objectContaining({
+            label: expect.stringContaining('Automation flow'),
+          }),
+        }),
+      );
+    });
+
     it('should include Contacts option', () => {
       const sidebarOptions = wrapper.findAllComponents(elements.sidebarOption);
       const props = sidebarOptions.map((option) => option.props());
@@ -255,6 +268,19 @@ describe('Sidebar.vue', () => {
         expect.objectContaining({
           option: expect.objectContaining({
             label: expect.stringContaining('Contacts'),
+          }),
+        }),
+      );
+    });
+
+    it('should include Campaigns option', () => {
+      const sidebarOptions = wrapper.findAllComponents(elements.sidebarOption);
+      const props = sidebarOptions.map((option) => option.props());
+
+      expect(props).toContainEqual(
+        expect.objectContaining({
+          option: expect.objectContaining({
+            label: expect.stringContaining('Campaigns'),
           }),
         }),
       );


### PR DESCRIPTION
## Description

### Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other

### Motivation and Context

Marketing-role users could not access Flows from the sidebar, even though that module is relevant to their workflow.

### Summary of Changes

- Adds the Flows module (`push` / Automation flow) to the marketing role sidebar options
- Updates Sidebar unit tests to cover the new option, expected count, and Campaigns assertion