### PR TITLE
LOC-26464: fix: Sync SSO invalid_domain locale string with Crowdin review

### DIFF
--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -674,7 +674,7 @@
       "description": "Exige que todos los miembros de la organización inicien sesión exclusivamente mediante Single Sign-On. Quienes acceden a la plataforma con contraseña perderán ese acceso y deberán autenticarse mediante tu proveedor de identidad.",
       "enable": "Habilitar SSO obligatorio",
       "helper": "Cuando está habilitado, el inicio de sesión con contraseña se desactiva para todos los usuarios de esta organización.",
-      "invalid_domain": "Ingresa un dominio sin {'@'} (por ejemplo: tuempresa.com)",
+      "invalid_domain": "Ingresa un dominio sin {'@'} (ejemplo: tuempresa.com)",
       "lockout_error": {
         "description": "Asegúrate de que al menos un administrador de tu organización tenga acceso mediante SSO antes de habilitar esta configuración.",
         "title": "Inicio de sesión SSO obligatorio para al menos un administrador"

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -674,7 +674,7 @@
       "description": "Solicită tuturor membrilor organizației să se autentifice exclusiv prin Single Sign-On. Utilizatorii care accesează platforma cu parolă vor pierde acest acces și vor trebui să se autentifice prin furnizorul de identitate.",
       "enable": "Activează SSO obligatoriu",
       "helper": "Când este activat, autentificarea cu parolă va fi dezactivată pentru toți utilizatorii din această organizație.",
-      "invalid_domain": "Introduceți un domeniu fără {'@'} (exemplu: yourcompany.com)",
+      "invalid_domain": "Introdu un domeniu fără {'@'} (exemplu: yourcompany.com)",
       "lockout_error": {
         "description": "Asigură-te că cel puțin un administrator din organizație are acces SSO înainte de a activa această setare.",
         "title": "Autentificare SSO obligatorie pentru cel puțin un administrator"


### PR DESCRIPTION
### Summary

Localization delivery for [LOC-26464](https://vtex-dev.atlassian.net/browse/LOC-26464).

Source: [PR#1156](https://github.com/weni-ai/weni-webapp/pull/1156)

Languages: PT, EN, ES, RO (Crowdin approved).