### PR TITLE
feat: Add webchat conversation starters to AI conversations improvements route

### DIFF
--- a/src/components/SystemAgentBuilder.vue
+++ b/src/components/SystemAgentBuilder.vue
@@ -1,10 +1,21 @@
 <script setup>
-import { onMounted, toRef, watch } from 'vue';
+import { computed, onMounted, onUnmounted, toRef, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 
 import getEnv from '@/utils/env';
 import ExternalSystem from './ExternalSystem.vue';
 import { useFederatedModule } from '@/composables/useFederatedModule';
+import { waitFor } from '@/utils/waitFor';
+
+const CONVERSATION_STARTER_PATHS = [
+  'ai-conversations/conversations',
+  'ai-conversations/conversations/improvements',
+];
+
+// The webchat widget discards conversation starters shortly after any SPA
+// navigation, so they have to be applied again once that delay has passed.
+const WEBCHAT_STARTERS_DELAY_MS = 400;
 
 const props = defineProps({
   modelValue: {
@@ -13,6 +24,7 @@ const props = defineProps({
   },
 });
 
+const { t, locale } = useI18n();
 const route = useRoute();
 const router = useRouter();
 
@@ -28,6 +40,37 @@ const { iframeRef, isModuleRoute, sharedStore, remount } = useFederatedModule({
   initialUseIframe: true,
   routeNameForUpdateRoute: route.name,
 });
+
+const shouldShowConversationStarters = computed(() =>
+  CONVERSATION_STARTER_PATHS.some((path) => route.path.endsWith(path)),
+);
+
+let webChatStartersTimeout = null;
+
+function scheduleWebChatConversationStarters() {
+  clearTimeout(webChatStartersTimeout);
+
+  webChatStartersTimeout = setTimeout(() => {
+    setWebChatConversationStarters();
+  }, WEBCHAT_STARTERS_DELAY_MS);
+}
+
+function setWebChatConversationStarters() {
+  // Leaving the page is always a navigation, which makes the widget drop
+  // the starters on its own, so there is nothing to clear.
+  if (!shouldShowConversationStarters.value) {
+    return;
+  }
+
+  waitFor(() => window.WebChat).then((WebChat) => {
+    if (shouldShowConversationStarters.value) {
+      WebChat.setConversationStarters([
+        t('agent_builder.conversation_starters.ask_a_question'),
+        t('agent_builder.conversation_starters.share_feedback'),
+      ]);
+    }
+  });
+}
 
 // AgentBuilder-specific: handle iframe route redirects from external messages
 function updateIframeRoute(path) {
@@ -57,6 +100,10 @@ onMounted(() => {
   });
 });
 
+onUnmounted(() => {
+  clearTimeout(webChatStartersTimeout);
+});
+
 // AgentBuilder-specific: remount when navigating between sub-routes
 watch(
   () => route.name,
@@ -65,6 +112,12 @@ watch(
       remount();
     }
   },
+);
+
+watch(
+  () => [shouldShowConversationStarters.value, route.fullPath, locale.value],
+  scheduleWebChatConversationStarters,
+  { immediate: true },
 );
 </script>
 

--- a/src/components/SystemAgentBuilder.vue
+++ b/src/components/SystemAgentBuilder.vue
@@ -9,7 +9,6 @@ import { useFederatedModule } from '@/composables/useFederatedModule';
 import { waitFor } from '@/utils/waitFor';
 
 const CONVERSATION_STARTER_PATHS = [
-  'ai-conversations/conversations',
   'ai-conversations/conversations/improvements',
 ];
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -270,6 +270,12 @@
     "intelligence": "Artificial Intelligence API",
     "nexus": "Nexus API"
   },
+  "agent_builder": {
+    "conversation_starters": {
+      "ask_a_question": "Ask question",
+      "share_feedback": "Share feedback"
+    }
+  },
   "common": {
     "see_all": "View all",
     "months": [

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -270,6 +270,12 @@
     "intelligence": "Artificial Intelligence API",
     "nexus": "Nexus API"
   },
+  "agent_builder": {
+    "conversation_starters": {
+      "ask_a_question": "Hacer pregunta",
+      "share_feedback": "Compartir feedback"
+    }
+  },
   "common": {
     "see_all": "Ver todo",
     "months": [

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -270,6 +270,12 @@
     "intelligence": "Artificial Intelligence API",
     "nexus": "Nexus API"
   },
+  "agent_builder": {
+    "conversation_starters": {
+      "ask_a_question": "Fazer pergunta",
+      "share_feedback": "Compartilhar feedback"
+    }
+  },
   "common": {
     "see_all": "Ver tudo",
     "months": [

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -270,6 +270,12 @@
     "intelligence": "API inteligență artificială",
     "nexus": "API Nexus"
   },
+  "agent_builder": {
+    "conversation_starters": {
+      "ask_a_question": "Pune întrebare",
+      "share_feedback": "Trimite feedback"
+    }
+  },
   "common": {
     "see_all": "Vizualizează tot",
     "months": [


### PR DESCRIPTION
## Description

### Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other

### Motivation and Context

The webchat widget discards conversation starters shortly after any SPA navigation, meaning they need to be reapplied after a short delay. Without this, conversation starters set on the AI conversations improvements page are lost whenever the user navigates.

### Summary of Changes

- Added logic in `SystemAgentBuilder.vue` to detect when the current route should display conversation starters (`ai-conversations/conversations/improvements`) and schedule their application via `setWebChatConversationStarters` after a 400ms delay to account for the webchat widget's discard behavior.
- A watcher on the route path, locale, and `shouldShowConversationStarters` ensures starters are reapplied on navigation or locale changes.
- Pending timeouts are cleared on component unmount to prevent stale callbacks.
- Added localized conversation starter strings ("Ask question" and "Share feedback") for English, Spanish, Brazilian Portuguese, and Romanian.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/1979d2cc-3b6d-42e6-9570-7a5dbcdbcab6.png)

