### PR TITLE
feat: Support opening microfrontend routes in a new tab

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -719,17 +719,24 @@ export default {
         );
         const routeName = CHATS_MODULE_TO_ROUTE_NAME[module] || module;
 
-        // Host router push drives navigation. Query params (e.g. uuid_room) must
-        // be parsed out of the path string — in iframe mode they travelled via
-        // ?next=; in federation getInitialModuleRoute reads route.query.
-        this.$router.push({
+        const route = {
           name: routeName,
           params: {
             projectUuid: this.$route.params.projectUuid,
             internal,
           },
           query,
-        });
+        };
+
+        if (payload?.openInNew) {
+          window.open(this.$router.resolve(route).href, '_blank');
+          return;
+        }
+
+        // Host router push drives navigation. Query params (e.g. uuid_room) must
+        // be parsed out of the path string — in iframe mode they travelled via
+        // ?next=; in federation getInitialModuleRoute reads route.query.
+        this.$router.push(route);
       } else if (event === 'chats:update-unread-messages') {
         this.unreadMessages = payload.unreadMessages;
       } else if (event === 'chats:theme') {


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

When navigating to a agent builder route from an event payload, there was no way to open the destination in a new browser tab. All navigation was forced through the current router context, limiting flexibility for certain use cases.

### Summary of Changes

Added support for an `openInNew` flag in the chat navigation event payload. When `payload.openInNew` is `true`, the resolved route href is opened in a new tab via `window.open` instead of pushing to the current router history. If the flag is absent or falsy, the existing `this.$router.push` behavior is preserved.