### PR TITLE
fix: prevent frozen Chats live desk by allowing only one chats federated mount at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.41.1] - 2026-07-30
+
+### Fixed
+
+- fix: prevent frozen Chats live desk after visiting Chats settings by allowing only one chats federated mount at a time
+
 ## [2.41.0] - 2026-07-30
 
 ### Added

--- a/src/composables/__tests__/useChatsFederatedModule.spec.js
+++ b/src/composables/__tests__/useChatsFederatedModule.spec.js
@@ -493,3 +493,114 @@ describe('useChatsFederatedModule defaultHomeRoute sync', () => {
     document.getElementById('chats-app')?.remove();
   });
 });
+
+describe('useChatsFederatedModule exclusive chats mounts', () => {
+  afterEach(() => {
+    document.getElementById('chats-app')?.remove();
+    document.getElementById('chats-settings-app')?.remove();
+  });
+
+  it('unmounts immediately when a sibling chats surface mounts', async () => {
+    vi.clearAllMocks();
+    sharedStoreState.auth.token = 'mock-token';
+    sharedStoreState.current.project.uuid = 'test-uuid';
+    modelValueRef.value = true;
+    setRouteState({
+      name: 'chats',
+      params: { internal: ['init'] },
+      query: {},
+    });
+
+    const { wrapper, getFedApi, mockMountedAppUnmount } = mountComposable();
+    await flushPromises();
+
+    expect(getFedApi().app.value).toBeTruthy();
+    mockMountedAppUnmount.mockClear();
+
+    window.dispatchEvent(
+      new CustomEvent('chats:exclusive-mount', {
+        detail: { containerId: 'chats-settings-app' },
+      }),
+    );
+    await flushPromises();
+
+    expect(mockMountedAppUnmount).toHaveBeenCalled();
+    expect(getFedApi().app.value).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it('unmounts the settings mount when modelValue becomes false', async () => {
+    vi.clearAllMocks();
+    sharedStoreState.auth.token = 'mock-token';
+    sharedStoreState.current.project.uuid = 'test-uuid';
+    modelValueRef.value = true;
+    setRouteState({
+      name: 'settingsChats',
+      params: { internal: ['init'] },
+      query: {},
+    });
+
+    const settingsModelValue = ref(true);
+    const { wrapper, getFedApi, mockMountedAppUnmount } = mountComposable({
+      containerId: 'chats-settings-app',
+      routeNames: ['settingsChats'],
+      forceRemountEvent: 'forceRemountChatsSettings',
+      routeNameForUpdateRoute: 'settingsChats',
+      basePath: '/settings',
+      modelValue: settingsModelValue,
+      inactivityTimeout: null,
+      activeModuleTracking: false,
+    });
+    await flushPromises();
+
+    expect(getFedApi().app.value).toBeTruthy();
+    mockMountedAppUnmount.mockClear();
+
+    settingsModelValue.value = false;
+    await flushPromises();
+
+    expect(mockMountedAppUnmount).toHaveBeenCalled();
+    expect(getFedApi().app.value).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it('unmounts live desk immediately when navigating to settingsChats', async () => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    sharedStoreState.auth.token = 'mock-token';
+    sharedStoreState.current.project.uuid = 'test-uuid';
+    modelValueRef.value = true;
+    setRouteState({
+      name: 'chats',
+      params: { internal: ['init'] },
+      query: {},
+    });
+
+    const { wrapper, getFedApi, mockMountedAppUnmount } = mountComposable();
+    await flushPromises();
+
+    expect(getFedApi().app.value).toBeTruthy();
+    mockMountedAppUnmount.mockClear();
+
+    setRouteState({
+      name: 'settingsChats',
+      params: { internal: ['init'] },
+      query: {},
+    });
+    modelValueRef.value = false;
+    await flushPromises();
+
+    expect(mockMountedAppUnmount).toHaveBeenCalled();
+    expect(getFedApi().app.value).toBeNull();
+
+    // Keep-alive timer must not fire a second unmount later.
+    mockMountedAppUnmount.mockClear();
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    expect(mockMountedAppUnmount).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+    vi.useRealTimers();
+  });
+});

--- a/src/composables/useChatsFederatedModule.js
+++ b/src/composables/useChatsFederatedModule.js
@@ -19,6 +19,17 @@ import {
 } from '@/utils/normalizeInternalPath';
 
 /**
+ * Broadcast when a chats surface (live desk or settings) successfully mounts.
+ * Sibling mounts must tear down immediately — two concurrent chats Vue apps
+ * share module-level Pinia (`getActivePinia`) and WebSocket listeners, which
+ * freezes the hidden live-desk DOM after visiting settings and returning.
+ */
+export const CHATS_EXCLUSIVE_MOUNT_EVENT = 'chats:exclusive-mount';
+
+/** Host routes that each own a chats federated mount (only one may be alive). */
+const CHATS_HOST_MOUNT_ROUTES = new Set(['chats', 'settingsChats']);
+
+/**
  * Chats-only federated module lifecycle (live desk + settings mounts).
  * Forked from useFederatedModule so legacy modules keep the pre-chats behavior.
  */
@@ -378,6 +389,9 @@ export function useChatsFederatedModule(config) {
       }
 
       setupRouterSync();
+      // Claim exclusive ownership before the host paints this surface so any
+      // sibling chats mount (live desk ↔ settings) tears down first.
+      announceExclusiveMount();
       // Let the host finish patching (e.g. hide LoadingModule) before the
       // child router navigates — concurrent host/child DOM updates cause
       // `nextSibling` errors during unmount.
@@ -434,6 +448,28 @@ export function useChatsFederatedModule(config) {
     }
   }
 
+  function announceExclusiveMount() {
+    window.dispatchEvent(
+      new CustomEvent(CHATS_EXCLUSIVE_MOUNT_EVENT, {
+        detail: { containerId },
+      }),
+    );
+  }
+
+  function onExclusiveMount(event) {
+    if (event.detail?.containerId === containerId) {
+      return;
+    }
+
+    // Another chats surface (live desk ↔ settings) took ownership — drop this
+    // instance before its Pinia/WS can poison the visible mount.
+    mountGeneration.value += 1;
+    if (isMounting.value) {
+      isMounting.value = false;
+    }
+    unmount();
+  }
+
   /**
    * Remount the federated module by navigating to home, unmounting,
    * and then mounting again with force.
@@ -457,6 +493,12 @@ export function useChatsFederatedModule(config) {
       themeEnforcementActive.value = !!active;
 
       if (!active) {
+        // Settings (no keep-alive) must release immediately. Live desk keeps the
+        // inactivity timer via the route watcher so insights↔chats stays fast.
+        if (inactivityTimeout === null && app.value) {
+          mountGeneration.value += 1;
+          unmount();
+        }
         return;
       }
 
@@ -541,7 +583,16 @@ export function useChatsFederatedModule(config) {
               sharedStore.setIsActiveFederatedModule(moduleName, false);
             }
 
-            if (inactivityTimeout !== null) {
+            // Another chats mount (settings) will take the remote — drop keep-alive
+            // immediately instead of waiting for the inactivity timer.
+            if (
+              inactivityTimeout !== null &&
+              CHATS_HOST_MOUNT_ROUTES.has(newRoute) &&
+              !routeNames.includes(newRoute)
+            ) {
+              mountGeneration.value += 1;
+              unmount();
+            } else if (inactivityTimeout !== null) {
               unmountTimeoutId.value = setTimeout(() => {
                 unmount();
               }, inactivityTimeout);
@@ -574,6 +625,7 @@ export function useChatsFederatedModule(config) {
 
   onMounted(() => {
     window.addEventListener(forceRemountEvent, remount);
+    window.addEventListener(CHATS_EXCLUSIVE_MOUNT_EVENT, onExclusiveMount);
 
     scheduleMountWhenReady();
   });
@@ -581,6 +633,7 @@ export function useChatsFederatedModule(config) {
   onUnmounted(() => {
     unmount();
     window.removeEventListener(forceRemountEvent, remount);
+    window.removeEventListener(CHATS_EXCLUSIVE_MOUNT_EVENT, onExclusiveMount);
   });
 
   return {


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
When navigating from the Chats live desk to Chats settings (or vice versa), two concurrent chats federated Vue app instances could exist simultaneously. Because both instances share module-level Pinia state and WebSocket listeners, the hidden live-desk DOM would become frozen after visiting settings and returning, making the live desk unusable.

### Summary of Changes
A new `chats:exclusive-mount` custom window event is introduced to enforce that only one chats federated mount may be alive at any given time. When a chats surface (live desk or settings) successfully mounts, it broadcasts this event with its `containerId`. Any sibling chats mount listening for this event will immediately tear itself down — incrementing its mount generation, clearing its mounting state, and calling `unmount()` — before the newly active surface can be poisoned by the stale instance's Pinia or WebSocket state.

Additionally, the settings mount (which has no keep-alive inactivity timer) now unmounts immediately when its `modelValue` becomes `false`, rather than waiting. The live desk route watcher was also updated to unmount immediately — instead of deferring via the inactivity timer — when navigating to another known chats host route such as `settingsChats`.

Tests were added to cover:
- The live desk unmounting immediately when a sibling chats surface dispatches the exclusive-mount event.
- The settings mount unmounting when its `modelValue` becomes `false`.
- The live desk unmounting immediately on navigation to `settingsChats`, with verification that the keep-alive timer does not trigger a redundant second unmount afterward.