### PR TITLE
feat: add desktop notification support to chats module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.42.1] - 2026-08-07
+
+### Added
+
+- feat: support Live-desk desktop notifications over Module Federation via `chatsToHost` (`chats:notification` and `chats:notification-request-permission`), using Connect's same-origin VTEX favicon and keeping the iframessa fallback for iframe mode
+
 ## [2.42.0] - 2026-08-05
 
 ### Added

--- a/src/app.vue
+++ b/src/app.vue
@@ -707,6 +707,8 @@ export default {
         'chats:redirect',
         'chats:update-unread-messages',
         'chats:theme',
+        'chats:notification',
+        'chats:notification-request-permission',
       ].includes(eventName);
     },
 
@@ -734,7 +736,33 @@ export default {
         this.unreadMessages = payload.unreadMessages;
       } else if (event === 'chats:theme') {
         this.chatsThemeStore.setTheme(payload.theme);
+      } else if (event === 'chats:notification') {
+        this.showDesktopNotification(payload.title, payload.options);
+      } else if (event === 'chats:notification-request-permission') {
+        this.requestDesktopNotificationPermission();
       }
+    },
+
+    requestDesktopNotificationPermission() {
+      if (!('Notification' in window)) return;
+      if (Notification.permission !== 'granted') {
+        Notification.requestPermission();
+      }
+    },
+
+    showDesktopNotification(title, options = {}) {
+      if (!('Notification' in window)) return;
+      if (Notification.permission !== 'granted') return;
+
+      // Always use Connect's same-origin VTEX favicon. In MF the chats remote
+      // may send a cross-origin SVG URL that Chrome can't paint in the toast,
+      // which makes the notification flash/disappear before you can read it.
+      const vtexIcon = favicons[''];
+      new Notification(title, {
+        ...options,
+        icon: vtexIcon,
+        badge: vtexIcon,
+      });
     },
 
     registerNotificationSupport() {
@@ -743,18 +771,14 @@ export default {
         return;
       }
 
+      // Iframe fallback: Chats still emits via iframessa when not federated.
       iframessa.on('notification.requestPermission', () => {
-        if (Notification.permission !== 'granted') {
-          Notification.requestPermission();
-        }
+        this.requestDesktopNotificationPermission();
       });
 
       iframessa.on('notification', ({ data }) => {
         const [title, options] = data;
-
-        if (Notification.permission === 'granted') {
-          new Notification(title, options);
-        }
+        this.showDesktopNotification(title, options);
       });
     },
 


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When running in a Micro Frontend (MF) context, the Chats remote can send a cross-origin SVG URL as the notification icon. Chrome is unable to paint cross-origin SVGs in desktop notification toasts, causing the notification to flash and disappear before the user can read it. Additionally, the notification logic was duplicated between the iframe and federated event paths.

### Summary of Changes
- Added two new allowed iframe event types: `chats:notification` and `chats:notification-request-permission`, enabling the federated Chats remote to trigger desktop notifications and permission requests through the standard event bus.
- Extracted notification permission request and notification display logic into dedicated methods (`requestDesktopNotificationPermission` and `showDesktopNotification`) to eliminate duplication between the iframe fallback and federated event paths.
- `showDesktopNotification` always uses Connect's same-origin VTEX favicon instead of any icon provided by the caller, preventing the cross-origin SVG issue in Chrome that caused notifications to flash and disappear.
- The existing `iframessa`-based notification handlers now delegate to the same shared methods, ensuring consistent behavior regardless of whether Chats is running federated or via iframe.