### PR TITLE
refactor: migrate Theme store from Vuex to Pinia

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="loading"
-    :class="['loading', `theme-${$store.state.Theme.name}`]"
+    :class="['loading', `theme-${themeStore.name}`]"
   >
     <UnnnicIconLoading size="64px" />
   </div>
@@ -185,6 +185,7 @@ import { useSharedStore } from './store/Shared.js';
 import { useAccountStore } from '@/store/account';
 import { useChatsThemeStore, CHATS_THEME_DARK } from './store/chatsTheme.js';
 import { buildChatsHostRedirectRoute } from '@/utils/normalizeInternalPath';
+import { useThemeStore } from '@/store/theme';
 
 const CHATS_DARK_ROUTES = new Set(['chats']);
 const CHATS_LIGHT_ROUTES = new Set(['settingsChats']);
@@ -234,9 +235,11 @@ export default {
   setup() {
     const featureFlagsStore = useFeatureFlagsStore();
     const chatsThemeStore = useChatsThemeStore();
+    const themeStore = useThemeStore();
     return {
       featureFlagsStore,
       chatsThemeStore,
+      themeStore,
     };
   },
 

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import store from './store';
 import i18n from './utils/plugins/i18n';
 import vueDebounce from 'vue-debounce';
 import { createPinia } from 'pinia';
+import { useThemeStore } from '@/store/theme';
 import Keycloak from './services/Keycloak';
 import UnnnicSystem from './utils/plugins/UnnnicSystem';
 import getEnv from '@/utils/env';
@@ -111,6 +112,7 @@ app.mixin({
 });
 
 app.use(createPinia());
+useThemeStore();
 app.use(router);
 app.use(store);
 app.use(i18n);

--- a/src/store/__tests__/theme.spec.js
+++ b/src/store/__tests__/theme.spec.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useThemeStore } from '@/store/theme';
+
+describe('useThemeStore', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.removeItem('theme');
+    document.body.removeAttribute('unnnic-theme');
+    setActivePinia(createPinia());
+  });
+
+  it('defaults to light and does not set the body attribute when storage is empty', () => {
+    const setAttribute = vi.spyOn(document.body, 'setAttribute');
+
+    const themeStore = useThemeStore();
+
+    expect(themeStore.name).toBe('light');
+    expect(setAttribute).not.toHaveBeenCalled();
+  });
+
+  it('hydrates name and the body attribute from localStorage', () => {
+    localStorage.setItem('theme', 'dark');
+
+    const themeStore = useThemeStore();
+
+    expect(themeStore.name).toBe('dark');
+    expect(document.body.getAttribute('unnnic-theme')).toBe('dark');
+  });
+
+  it('setTheme updates state, storage, and the body attribute', () => {
+    const themeStore = useThemeStore();
+
+    themeStore.setTheme('dark');
+
+    expect(themeStore.name).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(document.body.getAttribute('unnnic-theme')).toBe('dark');
+  });
+
+  it('defaults to light when localStorage getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+
+    const themeStore = useThemeStore();
+
+    expect(themeStore.name).toBe('light');
+    expect(document.body.getAttribute('unnnic-theme')).toBeNull();
+  });
+
+  it('updates state and the body attribute when localStorage setItem throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+
+    const themeStore = useThemeStore();
+
+    expect(() => themeStore.setTheme('dark')).not.toThrow();
+    expect(themeStore.name).toBe('dark');
+    expect(document.body.getAttribute('unnnic-theme')).toBe('dark');
+  });
+});

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -20,17 +20,8 @@ const store = createStore({
     RightBar,
     News,
     Brain,
-    Theme: {
-      state: () => ({ name: 'light' }),
-    },
   },
 });
-
-if (localStorage.getItem('theme')) {
-  store.state.Theme.name = localStorage.getItem('theme');
-
-  document.body.setAttribute('unnnic-theme', store.state.Theme.name);
-}
 
 store.state.Modal.lastId = 0;
 store.state.Modal.actives = [];

--- a/src/store/theme.js
+++ b/src/store/theme.js
@@ -1,0 +1,42 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+const STORAGE_KEY = 'theme';
+const DEFAULT_THEME = 'light';
+const UNNNIC_THEME_ATTRIBUTE = 'unnnic-theme';
+
+function readPersistedTheme() {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function applyUnnnicTheme(value) {
+  document.body.setAttribute(UNNNIC_THEME_ATTRIBUTE, value);
+}
+
+export const useThemeStore = defineStore('theme', () => {
+  const persisted = readPersistedTheme();
+  const name = ref(persisted || DEFAULT_THEME);
+
+  if (persisted) {
+    applyUnnnicTheme(persisted);
+  }
+
+  function setTheme(value) {
+    name.value = value;
+    try {
+      localStorage.setItem(STORAGE_KEY, value);
+    } catch {
+      // Ignore persistence failures (private mode, storage quota).
+    }
+    applyUnnnicTheme(value);
+  }
+
+  return {
+    name,
+    setTheme,
+  };
+});


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The theme state was previously managed inside the Vuex store as a plain state object, with initialization logic scattered in `store/index.js`. This approach made the theme store harder to test in isolation and inconsistent with the Pinia-based stores used elsewhere in the project.

### Summary of Changes
The `Theme` Vuex module has been replaced with a dedicated Pinia store (`useThemeStore`) defined in `src/store/theme.js`. The new store encapsulates theme persistence (reading from and writing to `localStorage`) and applies the `unnnic-theme` attribute to `document.body`. It handles storage failures gracefully, such as in private browsing mode or when storage quota is exceeded.

The store is initialized in `main.js` immediately after Pinia is registered, and `app.vue` now references `themeStore.name` instead of `$store.state.Theme.name`.

Unit tests covering default behavior, hydration from `localStorage`, `setTheme` updates, and error handling for both `getItem` and `setItem` failures have been added in `src/store/__tests__/theme.spec.js`.