### PR TITLE
refactor: migrate News store from Vuex to Pinia

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -186,6 +186,7 @@ import { useAccountStore } from '@/store/account';
 import { useChatsThemeStore, CHATS_THEME_DARK } from './store/chatsTheme.js';
 import { buildChatsHostRedirectRoute } from '@/utils/normalizeInternalPath';
 import { useThemeStore } from '@/store/theme';
+import { useNewsStore } from '@/store/news';
 
 const CHATS_DARK_ROUTES = new Set(['chats']);
 const CHATS_LIGHT_ROUTES = new Set(['settingsChats']);
@@ -236,10 +237,12 @@ export default {
     const featureFlagsStore = useFeatureFlagsStore();
     const chatsThemeStore = useChatsThemeStore();
     const themeStore = useThemeStore();
+    const newsStore = useNewsStore();
     return {
       featureFlagsStore,
       chatsThemeStore,
       themeStore,
+      newsStore,
     };
   },
 
@@ -517,7 +520,7 @@ export default {
         if (requiresAuth && !this.accountProfile) {
           await this.fetchProfile();
 
-          this.$store.dispatch('loadNews');
+          this.newsStore.loadNews();
 
           iframessa.getter('userInfo', () => {
             return {
@@ -679,7 +682,7 @@ export default {
     });
 
     this.registerNotificationSupport();
-    this.$store.dispatch('loadLatestNews');
+    this.newsStore.loadLatestNews();
   },
 
   methods: {

--- a/src/components/Topbar/Topbar.vue
+++ b/src/components/Topbar/Topbar.vue
@@ -57,18 +57,19 @@ import { computed, getCurrentInstance } from 'vue';
 import WarningTrialChip from '@/components/billing/WarningTrialChip.vue';
 import ProfileDropdown from './ProfileDropdown.vue';
 import i18n from '../../utils/plugins/i18n';
+import { useNewsStore } from '@/store/news';
 
 defineEmits(['openModalTrialPeriod']);
 
 const instance = getCurrentInstance();
 
 const store = instance.proxy['$store'];
+const newsStore = useNewsStore();
 
 const hasUpdates = computed(() => {
-  const userLastViewedMonth = store.state.News.lastViewedNews;
+  const userLastViewedMonth = newsStore.lastViewedNews;
 
-  const platformLastPublishedMoth =
-    store.state.News.platformNews.mostRecentMonth;
+  const platformLastPublishedMoth = newsStore.platformNews.mostRecentMonth;
 
   return userLastViewedMonth !== platformLastPublishedMoth;
 });

--- a/src/components/billing/WarningMaxActiveContacts.vue
+++ b/src/components/billing/WarningMaxActiveContacts.vue
@@ -25,6 +25,8 @@
 
 <script>
 import { mapActions, mapState } from 'vuex';
+import { mapStores } from 'pinia';
+import { useNewsStore } from '@/store/news';
 
 export default {
   props: {},
@@ -40,11 +42,12 @@ export default {
   },
 
   computed: {
+    ...mapStores(useNewsStore),
     ...mapState({
       currentOrg: (state) => state.Org.currentOrg,
     }),
     orgUuid() {
-      if (this.$store.state.News.status !== 'loaded') {
+      if (this.newsStore.status !== 'loaded') {
         return;
       }
 

--- a/src/components/common/RightBar/NotificationsUpdates.vue
+++ b/src/components/common/RightBar/NotificationsUpdates.vue
@@ -40,27 +40,16 @@
 </template>
 
 <script setup>
-import { computed, getCurrentInstance, onBeforeMount } from 'vue';
+import { computed, onBeforeMount } from 'vue';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import AppleEmoji from '../../../utils/plugins/AppleEmoji';
 import i18n from '../../../utils/plugins/i18n';
+import { useNewsStore } from '@/store/news';
 
-const instance = getCurrentInstance();
+const newsStore = useNewsStore();
 
-function use(name) {
-  return computed(() => {
-    const { proxy } = instance;
-    const item = proxy[`$${name}`];
-    return item;
-  });
-}
-
-const store = use('store');
-
-const platformNews = computed(() => {
-  return store.value.state.News.platformNews;
-});
+const platformNews = computed(() => newsStore.platformNews);
 
 const renderer = new marked.Renderer();
 
@@ -76,7 +65,7 @@ onBeforeMount(() => {
   if (platformNews.value.mostRecentMonth) {
     const mostRecentMonth = platformNews.value.mostRecentMonth;
 
-    store.value.state.News.lastViewedNews = mostRecentMonth;
+    newsStore.lastViewedNews = mostRecentMonth;
     localStorage.setItem('lastViewedNews', mostRecentMonth);
   }
 });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,7 +6,6 @@ import Project from './project';
 import Modal from './modal';
 import BillingSteps from './billingSteps';
 import RightBar from './RightBar';
-import News from './News';
 
 const store = createStore({
   modules: {
@@ -17,7 +16,6 @@ const store = createStore({
     Modal,
     BillingSteps,
     RightBar,
-    News,
   },
 });
 

--- a/src/store/news/__tests__/news.spec.js
+++ b/src/store/news/__tests__/news.spec.js
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { flushPromises } from '@vue/test-utils';
+import axios from 'axios';
+
+import { useNewsStore } from '@/store/news';
+import dashboard from '@/api/dashboard';
+import getEnv from '@/utils/env';
+
+vi.mock('@/api/dashboard', () => ({
+  default: {
+    newsletterList: vi.fn(),
+  },
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/env', () => ({
+  default: vi.fn((name) => {
+    const values = {
+      GITHUB_PLATFORM_UPDATES_REPOSITORY: 'org/platform-updates',
+      GITHUB_API: 'https://api.github.com',
+      GITHUB_CONTENT_API: 'https://raw.githubusercontent.com',
+    };
+
+    return values[name];
+  }),
+}));
+
+describe('useNewsStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.removeItem('lastViewedNews');
+    setActivePinia(createPinia());
+  });
+
+  describe('initial state', () => {
+    it('exposes the default state when localStorage is empty', () => {
+      const newsStore = useNewsStore();
+
+      expect(newsStore.status).toBeNull();
+      expect(newsStore.all).toEqual([]);
+      expect(newsStore.lastViewedNews).toBe('');
+      expect(newsStore.platformNews).toEqual({
+        status: null,
+        mostRecentMonth: '',
+        data: '',
+      });
+    });
+
+    it('hydrates lastViewedNews from localStorage', () => {
+      localStorage.setItem('lastViewedNews', '2024-08');
+
+      const newsStore = useNewsStore();
+
+      expect(newsStore.lastViewedNews).toBe('2024-08');
+    });
+  });
+
+  describe('loadNews', () => {
+    it('sets status to loading then loaded and reverses newsletter results', async () => {
+      dashboard.newsletterList.mockResolvedValue({
+        data: { results: [{ id: 1 }, { id: 2 }, { id: 3 }] },
+      });
+
+      const newsStore = useNewsStore();
+
+      newsStore.loadNews();
+
+      expect(newsStore.status).toBe('loading');
+      expect(dashboard.newsletterList).toHaveBeenCalledWith(0, 40);
+
+      await flushPromises();
+
+      expect(newsStore.status).toBe('loaded');
+      expect(newsStore.all).toEqual([{ id: 3 }, { id: 2 }, { id: 1 }]);
+    });
+
+    it('falls back to response.data when results is missing', async () => {
+      dashboard.newsletterList.mockResolvedValue({
+        data: [{ id: 'a' }, { id: 'b' }],
+      });
+
+      const newsStore = useNewsStore();
+
+      newsStore.loadNews();
+      await flushPromises();
+
+      expect(newsStore.all).toEqual([{ id: 'b' }, { id: 'a' }]);
+    });
+  });
+
+  describe('loadLatestNews', () => {
+    it('loads the most recent monthly markdown from GitHub', async () => {
+      const content = '# :us:\n\nUpdates';
+
+      axios.get
+        .mockResolvedValueOnce({
+          data: [
+            { name: 'develop', commit: { sha: 'dev-sha' } },
+            { name: 'main', commit: { sha: 'main-sha' } },
+          ],
+        })
+        .mockResolvedValueOnce({
+          data: {
+            tree: [
+              { path: 'README.md' },
+              { path: '2024-01.md' },
+              { path: '2024-08.md' },
+              { path: '2024-03.md' },
+            ],
+          },
+        })
+        .mockResolvedValueOnce({ data: content });
+
+      const newsStore = useNewsStore();
+
+      const result = newsStore.loadLatestNews();
+
+      expect(newsStore.platformNews.status).toBe('loading');
+
+      await result;
+
+      expect(getEnv).toHaveBeenCalledWith('GITHUB_PLATFORM_UPDATES_REPOSITORY');
+      expect(axios.get).toHaveBeenNthCalledWith(
+        1,
+        '/repos/org/platform-updates/branches',
+        {
+          baseURL: 'https://api.github.com',
+        },
+      );
+      expect(axios.get).toHaveBeenNthCalledWith(
+        2,
+        '/repos/org/platform-updates/git/trees/main-sha',
+        { baseURL: 'https://api.github.com' },
+      );
+      expect(axios.get).toHaveBeenNthCalledWith(
+        3,
+        '/org/platform-updates/main-sha/2024-08.md',
+        { baseURL: 'https://raw.githubusercontent.com' },
+      );
+      expect(newsStore.platformNews.status).toBe('complete');
+      expect(newsStore.platformNews.mostRecentMonth).toBe('2024-08');
+      expect(newsStore.platformNews.data).toBe(content);
+    });
+
+    it('sets platformNews status to error when the request fails', async () => {
+      axios.get.mockRejectedValue(new Error('network'));
+
+      const newsStore = useNewsStore();
+
+      await newsStore.loadLatestNews();
+
+      expect(newsStore.platformNews.status).toBe('error');
+    });
+  });
+});

--- a/src/store/news/__tests__/news.spec.js
+++ b/src/store/news/__tests__/news.spec.js
@@ -92,6 +92,20 @@ describe('useNewsStore', () => {
 
       expect(newsStore.all).toEqual([{ id: 'b' }, { id: 'a' }]);
     });
+
+    it('sets status to error when the request fails', async () => {
+      dashboard.newsletterList.mockRejectedValue(new Error('network'));
+
+      const newsStore = useNewsStore();
+
+      newsStore.loadNews();
+
+      expect(newsStore.status).toBe('loading');
+
+      await flushPromises();
+
+      expect(newsStore.status).toBe('error');
+    });
   });
 
   describe('loadLatestNews', () => {

--- a/src/store/news/index.js
+++ b/src/store/news/index.js
@@ -1,32 +1,30 @@
+import { defineStore } from 'pinia';
+import { reactive, ref } from 'vue';
 import axios from 'axios';
-import dashboard from '../../api/dashboard';
-import getEnv from '../../utils/env';
+import dashboard from '@/api/dashboard';
+import getEnv from '@/utils/env';
 
-const state = {
-  status: null,
-  all: [],
-  lastViewedNews: localStorage.getItem('lastViewedNews') || '',
+export const useNewsStore = defineStore('news', () => {
+  const status = ref(null);
+  const all = ref([]);
+  const lastViewedNews = ref(localStorage.getItem('lastViewedNews') || '');
 
-  platformNews: {
+  const platformNews = reactive({
     status: null,
     mostRecentMonth: '',
     data: '',
-  },
-};
+  });
 
-const getters = {};
-
-const actions = {
-  loadNews({ state }) {
-    state.status = 'loading';
+  function loadNews() {
+    status.value = 'loading';
     dashboard.newsletterList(0, 40).then((response) => {
-      state.status = 'loaded';
-      state.all = (response.data?.results || response.data).reverse();
+      status.value = 'loaded';
+      all.value = (response.data?.results || response.data).reverse();
     });
-  },
+  }
 
-  async loadLatestNews({ state }) {
-    state.platformNews.status = 'loading';
+  async function loadLatestNews() {
+    platformNews.status = 'loading';
 
     try {
       const repository = getEnv('GITHUB_PLATFORM_UPDATES_REPOSITORY');
@@ -59,23 +57,23 @@ const actions = {
         { baseURL: getEnv('GITHUB_CONTENT_API') },
       );
 
-      state.platformNews.status = 'complete';
-      state.platformNews.mostRecentMonth = mostRecent.replace(
+      platformNews.status = 'complete';
+      platformNews.mostRecentMonth = mostRecent.replace(
         /(\d{4}-\d{2}).*/,
         '$1',
       );
-      state.platformNews.data = content;
+      platformNews.data = content;
     } catch {
-      state.platformNews.status = 'error';
+      platformNews.status = 'error';
     }
-  },
-};
+  }
 
-const mutations = {};
-
-export default {
-  state,
-  getters,
-  actions,
-  mutations,
-};
+  return {
+    status,
+    all,
+    lastViewedNews,
+    platformNews,
+    loadNews,
+    loadLatestNews,
+  };
+});

--- a/src/store/news/index.js
+++ b/src/store/news/index.js
@@ -17,10 +17,15 @@ export const useNewsStore = defineStore('news', () => {
 
   function loadNews() {
     status.value = 'loading';
-    dashboard.newsletterList(0, 40).then((response) => {
-      status.value = 'loaded';
-      all.value = (response.data?.results || response.data).reverse();
-    });
+    dashboard
+      .newsletterList(0, 40)
+      .then((response) => {
+        status.value = 'loaded';
+        all.value = (response.data?.results || response.data).reverse();
+      })
+      .catch(() => {
+        status.value = 'error';
+      });
   }
 
   async function loadLatestNews() {

--- a/tests/unit/unit/components/billing/WarningMaxActiveContacts.spec.js
+++ b/tests/unit/unit/components/billing/WarningMaxActiveContacts.spec.js
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import WarningMaxActiveContacts from '@/components/billing/WarningMaxActiveContacts.vue';
 import { createStore } from 'vuex';
+import { createTestingPinia } from '@pinia/testing';
 
 import { org } from '../../../__mocks__';
 
@@ -28,9 +29,6 @@ describe('WarningMaxActiveContacts.vue', () => {
           },
         },
       },
-      News: {
-        status: null,
-      },
     };
     getters = {
       currentOrg() {
@@ -44,7 +42,16 @@ describe('WarningMaxActiveContacts.vue', () => {
     });
     wrapper = shallowMount(WarningMaxActiveContacts, {
       global: {
-        plugins: [store],
+        plugins: [
+          store,
+          createTestingPinia({
+            initialState: {
+              news: {
+                status: null,
+              },
+            },
+          }),
+        ],
         stubs: {
           UnnnicIconSvg: true,
           UnnnicSlider: true,

--- a/tests/unit/unit/components/common/RightBar/Notifications.spec.js
+++ b/tests/unit/unit/components/common/RightBar/Notifications.spec.js
@@ -6,8 +6,9 @@ import UnnnicSystem from '@/utils/plugins/UnnnicSystem';
 import { createRouter, createWebHistory } from 'vue-router';
 import { createStore } from 'vuex';
 
+import { createTestingPinia } from '@pinia/testing';
+
 import StoreProject from '@/store/project/index.js';
-import StoreNews from '@/store/News/index.js';
 
 vi.mock('@/api/projects.js', () => ({
   default: {
@@ -57,14 +58,13 @@ const router = createRouter({
 const store = createStore({
   modules: {
     Project: StoreProject,
-    News: StoreNews,
   },
 });
 
 const setup = () =>
   mount(Notifications, {
     global: {
-      plugins: [UnnnicSystem, router, store],
+      plugins: [UnnnicSystem, router, store, createTestingPinia()],
     },
     props: {},
   });

--- a/tests/unit/unit/components/common/RightBar/NotificationsUpdates.spec.js
+++ b/tests/unit/unit/components/common/RightBar/NotificationsUpdates.spec.js
@@ -1,33 +1,27 @@
 import NotificationsUpdates from '@/components/common/RightBar/NotificationsUpdates.vue';
 import { mount } from '@vue/test-utils';
 import { vi } from 'vitest';
-import { createStore } from 'vuex';
+import { createTestingPinia } from '@pinia/testing';
+import { useNewsStore } from '@/store/news';
 
-const store = createStore({
-  state() {
-    return {
-      News: {
-        lastViewedNews: null,
+const PLATFORM_NEWS_DATA = `"# :brazil:\n\n### :rocket: Atualizações e melhorias\n\n#### Nova Topbar:\n\nA topbar da plataforma está de cara nova! [Conheça](http://google.com)\n\n#### Nova Sidebar:\n\nA sidebar da plataforma está de cara nova! [Conheça](http://google.com)\n\n### :fly: Correções de bugs\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\n\n# :us:\n\n### :rocket: Updates and improvements\n\n#### New Insights module:\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. [Conheça](http://google.com)\n\n#### New Insights module:\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. [Conheça](http://google.com)\n\n### :fly: Bug fixes\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\n\n# :es:\n\n### :rocket: Actualizaciones y mejoras\n\n#### Nuevo módulo Insights:\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. [Conheça](http://google.com)\n\n#### Nuevo módulo Insights:\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. [Conheça](http://google.com)\n\n### :fly: Corrección de errores\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n"`;
 
-        platformNews: {
-          status: null,
-          mostRecentMonth: '2024-08',
-          data: `"# :brazil:\n\n### :rocket: Atualizações e melhorias\n\n#### Nova Topbar:\n\nA topbar da plataforma está de cara nova! [Conheça](http://google.com)\n\n#### Nova Sidebar:\n\nA sidebar da plataforma está de cara nova! [Conheça](http://google.com)\n\n### :fly: Correções de bugs\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\n\n# :us:\n\n### :rocket: Updates and improvements\n\n#### New Insights module:\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. [Conheça](http://google.com)\n\n#### New Insights module:\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. [Conheça](http://google.com)\n\n### :fly: Bug fixes\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\n\n# :es:\n\n### :rocket: Actualizaciones y mejoras\n\n#### Nuevo módulo Insights:\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. [Conheça](http://google.com)\n\n#### Nuevo módulo Insights:\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. [Conheça](http://google.com)\n\n### :fly: Corrección de errores\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n"`,
-        },
-      },
-    };
-  },
+const setup = () => {
+  const pinia = createTestingPinia({ stubActions: false });
+  const newsStore = useNewsStore();
 
-  actions: {},
-});
+  newsStore.lastViewedNews = null;
+  newsStore.platformNews.status = null;
+  newsStore.platformNews.mostRecentMonth = '2024-08';
+  newsStore.platformNews.data = PLATFORM_NEWS_DATA;
 
-const setup = () =>
-  mount(NotificationsUpdates, {
+  return mount(NotificationsUpdates, {
     global: {
-      plugins: [store],
+      plugins: [pinia],
     },
     props: {},
   });
+};
 
 window.localStorage.setItem = vi.fn();
 
@@ -35,7 +29,9 @@ describe('NotificationsUpdates.vue', () => {
   it('updates lastViewedNews to the most recent platform news month update', () => {
     setup();
 
-    expect(store.state.News.lastViewedNews).toBe('2024-08');
+    const newsStore = useNewsStore();
+
+    expect(newsStore.lastViewedNews).toBe('2024-08');
 
     expect(window.localStorage.setItem).toHaveBeenCalledWith(
       'lastViewedNews',


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The `News` Vuex module was tightly coupled to the global Vuex store, making it harder to test and maintain. Migrating it to a Pinia store aligns it with the project's direction toward Pinia and enables better composability and testability.

### Summary of Changes
- Converted the `News` Vuex module into a Pinia store (`useNewsStore`) using the Composition API style (`defineStore` with `ref` and `reactive`).
- Removed the `News` module from the Vuex store registration in `src/store/index.js`.
- Replaced all `$store.dispatch('loadNews')` and `$store.dispatch('loadLatestNews')` calls in `app.vue` with direct calls to `newsStore.loadNews()` and `newsStore.loadLatestNews()`.
- Updated `Topbar.vue`, `WarningMaxActiveContacts.vue`, and `NotificationsUpdates.vue` to consume state from `useNewsStore` instead of `$store.state.News`.
- Replaced direct `store.state.News.lastViewedNews` mutation in `NotificationsUpdates.vue` with a direct assignment to the Pinia store ref.
- Added a dedicated unit test suite for `useNewsStore` covering initial state, `loadNews`, and `loadLatestNews` behaviors, including error handling.
- Updated existing component tests to use `createTestingPinia` instead of a Vuex-based `News` module mock.