### PR TITLE
fix: Stops duplicate API calls from federated sharedStore

### DIFF
--- a/src/api/BillingApiInstance.js
+++ b/src/api/BillingApiInstance.js
@@ -1,37 +1,15 @@
 import getEnv from '../utils/env.js';
 import axios from 'axios';
-import keycloak from '../services/Keycloak';
-import _ from 'lodash';
+import {
+  attachAuthorizationHeader,
+  attachSessionExpirationHandler,
+} from './interceptors';
 
 const billingHttp = axios.create({
   baseURL: getEnv('BILLING_API_URL') || '',
 });
 
-billingHttp.interceptors.request.use((config) => {
-  config.headers['Authorization'] = `Bearer ${keycloak?.keycloak?.token}`;
-  return config;
-});
-
-billingHttp.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  async function (error) {
-    const detail = _.get(error, 'response.data.detail');
-    const status = _.get(error, 'response.status');
-
-    if (
-      [
-        "User session not found or doesn't have client attached on it",
-        'Session expired',
-      ].includes(detail) ||
-      status === 401
-    ) {
-      keycloak.keycloak.logout();
-    }
-
-    return Promise.reject(error);
-  },
-);
+attachAuthorizationHeader(billingHttp);
+attachSessionExpirationHandler(billingHttp);
 
 export default billingHttp;

--- a/src/api/__tests__/interceptors.spec.js
+++ b/src/api/__tests__/interceptors.spec.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import {
+  attachAuthorizationHeader,
+  attachSessionExpirationHandler,
+} from '@/api/interceptors';
+
+const { keycloakService } = vi.hoisted(() => ({
+  keycloakService: {
+    keycloak: {
+      token: undefined,
+      logout: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/services/Keycloak', () => ({ default: keycloakService }));
+
+function createInstance({ failWith } = {}) {
+  const instance = axios.create();
+  const sentRequests = [];
+
+  instance.defaults.adapter = async (config) => {
+    sentRequests.push(config);
+
+    if (failWith) {
+      const error = new Error('Request failed');
+      error.config = config;
+      error.response = failWith;
+      throw error;
+    }
+
+    return { data: {}, status: 200, statusText: 'OK', headers: {}, config };
+  };
+
+  return { instance, sentRequests };
+}
+
+describe('attachAuthorizationHeader', () => {
+  beforeEach(() => {
+    keycloakService.keycloak.token = undefined;
+  });
+
+  it('should send the current Keycloak token as a bearer credential', async () => {
+    keycloakService.keycloak.token = 'a-valid-token';
+
+    const { instance, sentRequests } = createInstance();
+    attachAuthorizationHeader(instance);
+
+    await instance.get('/anything');
+
+    expect(sentRequests[0].headers.Authorization).toBe('Bearer a-valid-token');
+  });
+
+  it('should omit the header entirely when there is no token', async () => {
+    const { instance, sentRequests } = createInstance();
+    attachAuthorizationHeader(instance);
+
+    await instance.get('/anything');
+
+    expect(sentRequests[0].headers.Authorization).toBeUndefined();
+  });
+
+  it('should read the token on every request instead of caching it', async () => {
+    const { instance, sentRequests } = createInstance();
+    attachAuthorizationHeader(instance);
+
+    await instance.get('/anything');
+    keycloakService.keycloak.token = 'refreshed-token';
+    await instance.get('/anything');
+
+    expect(sentRequests[0].headers.Authorization).toBeUndefined();
+    expect(sentRequests[1].headers.Authorization).toBe(
+      'Bearer refreshed-token',
+    );
+  });
+});
+
+describe('attachSessionExpirationHandler', () => {
+  beforeEach(() => {
+    keycloakService.keycloak.token = 'a-valid-token';
+    keycloakService.keycloak.logout.mockClear();
+  });
+
+  function createHandledInstance(failWith) {
+    const { instance } = createInstance({ failWith });
+
+    attachAuthorizationHeader(instance);
+    attachSessionExpirationHandler(instance);
+
+    return instance;
+  }
+
+  it('should pass successful responses through untouched', async () => {
+    const instance = createHandledInstance();
+
+    const response = await instance.get('/anything');
+
+    expect(response.status).toBe(200);
+    expect(keycloakService.keycloak.logout).not.toHaveBeenCalled();
+  });
+
+  it('should log the user out when an authenticated request is rejected with 401', async () => {
+    const instance = createHandledInstance({ status: 401, data: {} });
+
+    await expect(instance.get('/anything')).rejects.toThrow('Request failed');
+
+    expect(keycloakService.keycloak.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    "User session not found or doesn't have client attached on it",
+    'Session expired',
+  ])('should log the user out when the backend answers "%s"', async (detail) => {
+    const instance = createHandledInstance({ status: 403, data: { detail } });
+
+    await expect(instance.get('/anything')).rejects.toThrow('Request failed');
+
+    expect(keycloakService.keycloak.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not log the user out when the rejected request carried no token', async () => {
+    keycloakService.keycloak.token = undefined;
+
+    const instance = createHandledInstance({ status: 401, data: {} });
+
+    await expect(instance.get('/anything')).rejects.toThrow('Request failed');
+
+    expect(keycloakService.keycloak.logout).not.toHaveBeenCalled();
+  });
+
+  it('should not log the user out on errors unrelated to the session', async () => {
+    const instance = createHandledInstance({ status: 500, data: {} });
+
+    await expect(instance.get('/anything')).rejects.toThrow('Request failed');
+
+    expect(keycloakService.keycloak.logout).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/brain.js
+++ b/src/api/brain.js
@@ -1,15 +1,12 @@
 import axios from 'axios';
-import keycloak from '../services/Keycloak';
 import getEnv from '../utils/env';
+import { attachAuthorizationHeader } from './interceptors';
 
 const nexus = axios.create({
   baseURL: getEnv('NEXUS_API'),
 });
 
-nexus.interceptors.request.use((config) => {
-  config.headers['Authorization'] = `Bearer ${keycloak?.keycloak?.token}`;
-  return config;
-});
+attachAuthorizationHeader(nexus);
 
 export default {
   edit({ projectUuid, brainOn }) {

--- a/src/api/chats.js
+++ b/src/api/chats.js
@@ -1,16 +1,13 @@
 import axios from 'axios';
 import getEnv from '../utils/env';
-import keycloak from '../services/Keycloak';
 import project from '../store/project';
+import { attachAuthorizationHeader } from './interceptors';
 
 const chatsHttp = axios.create({
   baseURL: getEnv('CHATS_API_URL'),
 });
 
-chatsHttp.interceptors.request.use((config) => {
-  config.headers['Authorization'] = `Bearer ${keycloak?.keycloak?.token}`;
-  return config;
-});
+attachAuthorizationHeader(chatsHttp);
 
 export default {
   async getProjectInfo(projectUuid) {

--- a/src/api/interceptors.js
+++ b/src/api/interceptors.js
@@ -1,0 +1,59 @@
+import _ from 'lodash';
+import keycloak from '../services/Keycloak';
+
+const INVALID_SESSION_DETAILS = [
+  "User session not found or doesn't have client attached on it",
+  'Session expired',
+];
+
+/**
+ * Sends the Keycloak bearer token on every request of the given axios instance.
+ *
+ * The header is omitted while there is no token, because `Bearer undefined`
+ * reaches the backend as a malformed credential and comes back as a 401 that is
+ * indistinguishable from an expired session.
+ *
+ * @param {import('axios').AxiosInstance} instance
+ */
+export function attachAuthorizationHeader(instance) {
+  instance.interceptors.request.use((config) => {
+    const token = keycloak?.keycloak?.token;
+
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    return config;
+  });
+}
+
+/**
+ * Logs the user out when the backend rejects their session.
+ *
+ * Only requests that actually carried a token are considered: an unauthenticated
+ * request says nothing about the validity of the current session, so reacting to
+ * its 401 would sign out a perfectly valid user.
+ *
+ * @param {import('axios').AxiosInstance} instance
+ */
+export function attachSessionExpirationHandler(instance) {
+  instance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      const isSessionInvalid =
+        INVALID_SESSION_DETAILS.includes(
+          _.get(error, 'response.data.detail'),
+        ) || _.get(error, 'response.status') === 401;
+
+      const wasAuthenticated = Boolean(
+        _.get(error, 'config.headers.Authorization'),
+      );
+
+      if (isSessionInvalid && wasAuthenticated) {
+        keycloak.keycloak.logout();
+      }
+
+      return Promise.reject(error);
+    },
+  );
+}

--- a/src/api/request.js
+++ b/src/api/request.js
@@ -1,33 +1,11 @@
-import _ from 'lodash';
 import ApiInstance from './ApiInstance';
-import keycloak from '../services/Keycloak';
+import {
+  attachAuthorizationHeader,
+  attachSessionExpirationHandler,
+} from './interceptors';
 
-ApiInstance.interceptors.request.use((config) => {
-  config.headers['Authorization'] = `Bearer ${keycloak?.keycloak?.token}`;
-  return config;
-});
-
-ApiInstance.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  async function (error) {
-    const detail = _.get(error, 'response.data.detail');
-    const status = _.get(error, 'response.status');
-
-    if (
-      [
-        "User session not found or doesn't have client attached on it",
-        'Session expired',
-      ].includes(detail) ||
-      status === 401
-    ) {
-      keycloak.keycloak.logout();
-    }
-
-    return Promise.reject(error);
-  },
-);
+attachAuthorizationHeader(ApiInstance);
+attachSessionExpirationHandler(ApiInstance);
 
 export default {
   $http() {

--- a/src/store/Shared.js
+++ b/src/store/Shared.js
@@ -1,7 +1,15 @@
-import { computed, reactive } from 'vue';
+import { reactive } from 'vue';
 import { defineStore } from 'pinia';
-import rootStore from '@/store';
 
+/**
+ * Exposed to federated remotes as `connect/sharedStore`, which means it is
+ * evaluated inside the container runtime (`remoteEntry.js`) — a module registry
+ * separate from the host's. Every module it imports gets a second instance
+ * there, so importing the Vuex root store used to duplicate the whole app
+ * (router, views, Keycloak client, composable caches). Keep this file free of
+ * app imports: state that mirrors Vuex is pushed in from the mutation that
+ * owns it, never pulled from here.
+ */
 export const useSharedStore = defineStore('shared', () => {
   const user = reactive({
     firstName: '',
@@ -52,27 +60,28 @@ export const useSharedStore = defineStore('shared', () => {
     auth.token = token;
   }
 
-  const currentProjectUuid = computed(() => {
-    return rootStore.state.Project.currentProject?.uuid;
+  const currentProject = reactive({
+    uuid: undefined,
+    type: undefined,
   });
-  const currentProjectType = computed(
-    () => rootStore.state.Project.currentProject?.project_type,
-  );
+
+  function setCurrentProject(project) {
+    currentProject.uuid = project?.uuid;
+    currentProject.type = project?.project_type;
+  }
 
   return {
     user,
     auth,
     current: {
-      project: {
-        uuid: currentProjectUuid,
-        type: currentProjectType,
-      },
+      project: currentProject,
     },
     chats,
     isActiveFederatedModules,
     setUser,
     setLanguage,
     setAuthToken,
+    setCurrentProject,
     setIsActiveFederatedModule,
     setChatsTheme,
     setChatsUnreadMessages,

--- a/src/store/__tests__/Shared.spec.js
+++ b/src/store/__tests__/Shared.spec.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useSharedStore } from '@/store/Shared';
+
+const project = {
+  uuid: 'a-project-uuid',
+  project_type: 'commerce',
+  name: 'Irrelevant to the shared store',
+};
+
+describe('useSharedStore current project', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should expose an empty current project without a Vuex store present', () => {
+    const sharedStore = useSharedStore();
+
+    expect(sharedStore.current.project.uuid).toBeUndefined();
+    expect(sharedStore.current.project.type).toBeUndefined();
+  });
+
+  it('should expose the uuid and type of the project it receives', () => {
+    const sharedStore = useSharedStore();
+
+    sharedStore.setCurrentProject(project);
+
+    expect(sharedStore.current.project.uuid).toBe('a-project-uuid');
+    expect(sharedStore.current.project.type).toBe('commerce');
+  });
+
+  it('should clear the current project when it is unset', () => {
+    const sharedStore = useSharedStore();
+
+    sharedStore.setCurrentProject(project);
+    sharedStore.setCurrentProject(null);
+
+    expect(sharedStore.current.project.uuid).toBeUndefined();
+    expect(sharedStore.current.project.type).toBeUndefined();
+  });
+});

--- a/src/store/project/__tests__/mutations.spec.js
+++ b/src/store/project/__tests__/mutations.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useSharedStore } from '@/store/Shared';
+import mutations from '@/store/project/mutations';
+
+vi.mock('@/store', () => ({
+  default: {
+    state: {
+      Project: {
+        projects: [{ orgUuid: 'an-org-uuid', data: [] }],
+      },
+    },
+  },
+}));
+
+const project = {
+  uuid: 'a-project-uuid',
+  project_type: 'commerce',
+  organization: 'an-org-uuid',
+};
+
+describe('project mutations', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('setCurrentProject', () => {
+    it('should store the project and mirror it into the shared store', () => {
+      const state = { currentProject: null };
+
+      mutations.setCurrentProject(state, project);
+
+      expect(state.currentProject).toBe(project);
+      expect(useSharedStore().current.project.uuid).toBe('a-project-uuid');
+      expect(useSharedStore().current.project.type).toBe('commerce');
+    });
+
+    it('should clear the shared store when the project is unset', () => {
+      const state = { currentProject: project };
+
+      mutations.setCurrentProject(state, null);
+
+      expect(state.currentProject).toBeNull();
+      expect(useSharedStore().current.project.uuid).toBeUndefined();
+    });
+  });
+
+  describe('PROJECT_CREATE_SUCCESS', () => {
+    it('should mirror the newly created project into the shared store', () => {
+      const state = { currentProject: null, loadingCreateProject: true };
+
+      mutations.PROJECT_CREATE_SUCCESS(state, project);
+
+      expect(state.currentProject).toBe(project);
+      expect(state.loadingCreateProject).toBe(false);
+      expect(useSharedStore().current.project.uuid).toBe('a-project-uuid');
+    });
+  });
+});

--- a/src/store/project/mutations.js
+++ b/src/store/project/mutations.js
@@ -1,7 +1,16 @@
 import store from '../../store';
+import { useSharedStore } from '../Shared';
+
+function setSharedCurrentProject(project) {
+  useSharedStore().setCurrentProject(project);
+}
 
 export default {
-  setCurrentProject: (state, project) => (state.currentProject = project),
+  setCurrentProject: (state, project) => {
+    state.currentProject = project;
+
+    setSharedCurrentProject(project);
+  },
 
   setChampionChatbot: (state, value) => {
     state.championChatbots = {
@@ -25,6 +34,8 @@ export default {
 
     state.currentProject = project;
     state.loadingCreateProject = false;
+
+    setSharedCurrentProject(project);
   },
   PROJECT_CREATE_ERROR: (state, createProjectError) => {
     state.errorCreateProject = createProjectError;


### PR DESCRIPTION
### Type of Change

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [x] Tests
- [ ] Chore
- [ ] Locales

### Why

Opening project settings fired `GET /v2/currencies` twice. The first request succeeded; the second returned 401 with `Authorization: Bearer undefined`.

The composable already memoizes the call at module scope. The second request came from a **second copy of the app** instantiated inside Module Federation's `remoteEntry.js`. `connect/sharedStore` imported the Vuex root store, which pulled in the router, views, a second Keycloak client (never `init()`'d, so `token` was `undefined`), and a second `useProjectSettings` with an empty cache.

In development, Vue HMR then `reload()`'d the already-mounted `ProjectPreferences`, running `setup()` against that duplicate module. The response interceptor treated any 401 as session expiry, so this was also one step away from signing the user out.

The HMR cascade is dev-only. The duplicate graph (second Vuex store, router, and Keycloak client) was created in production too.

### What Changed

- `src/store/Shared.js` is now a leaf module: it no longer imports `@/store`. Current project is Pinia state.
- `src/store/project/mutations.js` pushes `uuid` / `project_type` into the shared store on `setCurrentProject` and `PROJECT_CREATE_SUCCESS` (same inversion as `account/mutations.js` for the user profile).
- Public remote shape is unchanged: `current.project.uuid`, `current.project.type`. `setCurrentProject` is additive.
- Auth interceptors extracted to `src/api/interceptors.js` and reused by `request.js`, `BillingApiInstance.js`, `brain.js`, and `chats.js`:
    - omit `Authorization` when there is no token (never send `Bearer undefined`)
    - logout only if the failed request actually carried a token
- Tests covering the header guard, logout conditions, and project mirroring.

The exposed `sharedStore` chunk is ~4 KB with no Vuex, router, Keycloak, or views. Previously it was the whole app.

### Diagram

```mermaid
flowchart TD
  subgraph before [Before]
    Remote["agent_builder remote"] --> RE["remoteEntry.js"]
    RE --> SharedOld["Shared.js"]
    SharedOld --> Vuex["@/store"]
    Vuex --> Getters["org/getters.js"]
    Getters --> Router["@/router"]
    Router --> Views["home.vue / dashboard.vue"]
    Views --> Duplicate["2nd Keycloak + 2nd useProjectSettings"]
    Duplicate --> Req2["GET /v2/currencies Bearer undefined"]
  end

  subgraph after [After]
    Remote2["agent_builder remote"] --> RE2["remoteEntry.js"]
    RE2 --> SharedNew["Shared.js leaf"]
    Mutations["project/mutations.js"] -->|setCurrentProject| SharedNew
  end
```