### PR TITLE
feat: add currency management to project settings

### DIFF
--- a/src/api/projects.js
+++ b/src/api/projects.js
@@ -159,14 +159,19 @@ export default {
       .get(`v2/omie/${info}?app_key=${appKey}&app_secret=${appSecret}`);
   },
 
-  editProject(
+  getCurrencies() {
+    return request.$http().get('/v2/currencies');
+  },
+
+  editProject({
     name,
     organization,
     projectUuid,
     timezone,
     description,
     language,
-  ) {
+    currency,
+  }) {
     return request
       .$http()
       .patch(`/v2/organizations/${organization}/projects/${projectUuid}/`, {
@@ -174,6 +179,7 @@ export default {
         description,
         timezone,
         language,
+        currency,
       });
   },
 

--- a/src/components/common/RightBar/Index.vue
+++ b/src/components/common/RightBar/Index.vue
@@ -124,6 +124,7 @@
           :projectDescription="projectDescription"
           :projectTimezone="projectTimezone"
           :projectLanguage="projectLanguage"
+          :projectCurrency="projectCurrency"
           :authorizations="projectAuthorizations"
           :pendingAuthorizations="projectPendingAuthorizations"
           :hasChat="projectHasChat"
@@ -199,6 +200,10 @@ export default {
       default: '',
     },
     projectLanguage: {
+      type: String,
+      default: '',
+    },
+    projectCurrency: {
       type: String,
       default: '',
     },

--- a/src/components/common/RightBar/ProjectSettings.vue
+++ b/src/components/common/RightBar/ProjectSettings.vue
@@ -34,6 +34,17 @@
         />
       </UnnnicFormElement>
 
+      <UnnnicFormElement :label="$t('settings.workspace.currency')">
+        <UnnnicSelect
+          :modelValue="currency"
+          :options="currencyOptions"
+          enableSearch
+          :search="currencySearch"
+          @update:search="currencySearch = $event"
+          @update:model-value="currency = $event"
+        />
+      </UnnnicFormElement>
+
       <section
         v-if="isEnableToExtendedMode"
         class="weni-update-project__extended-mode"
@@ -160,6 +171,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  projectCurrency: {
+    type: String,
+    default: '',
+  },
   authorizations: {
     type: Array,
     default: () => [],
@@ -185,8 +200,10 @@ const {
   description,
   timezone,
   language,
+  currency,
   timezoneOptions,
   languageOptions,
+  currencyOptions,
   initializeFromProject,
   isSaveDisabled,
   saveProject,
@@ -199,6 +216,7 @@ const isUserEnabledExtendedMode = ref(false);
 
 const timezoneSearch = ref('');
 const languageSearch = ref('');
+const currencySearch = ref('');
 
 // Create a project-like object from props for the composable functions
 const projectFromProps = computed(() => ({
@@ -206,6 +224,7 @@ const projectFromProps = computed(() => ({
   description: props.projectDescription,
   timezone: props.projectTimezone,
   language: props.projectLanguage,
+  currency: props.projectCurrency,
 }));
 
 // Check if form has changes compared to props

--- a/src/components/projects/ProjectList.vue
+++ b/src/components/projects/ProjectList.vue
@@ -341,7 +341,10 @@ export default {
 
       this.$emit('select-project', project, route);
     },
-    updateProject(projectUuid, { name, timezone, description }) {
+    updateProject(
+      projectUuid,
+      { name, timezone, description, language, currency },
+    ) {
       const project = this.orgProjects.data.find(
         (project) => project.uuid === projectUuid,
       );
@@ -349,6 +352,8 @@ export default {
       project.name = name;
       project.description = description;
       project.timezone = timezone;
+      project.language = language;
+      project.currency = currency;
     },
     updateProjectStatus(projectUuid, status) {
       const project = this.orgProjects.data.find(

--- a/src/components/projects/ProjectListItem.vue
+++ b/src/components/projects/ProjectListItem.vue
@@ -232,6 +232,7 @@ export default {
           projectDescription: this.project.description,
           projectTimezone: this.project.timezone,
           projectLanguage: this.project.language,
+          projectCurrency: this.project.currency,
           projectAuthorizations: this.authorizations.users,
           projectPendingAuthorizations: this.pendingAuthorizations.users,
           projectHasChat: this.hasChat,

--- a/src/composables/useProjectSettings.js
+++ b/src/composables/useProjectSettings.js
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n';
 import _ from 'lodash';
 import moment from 'moment-timezone';
 import countries from '@/assets/countries';
+import projects from '@/api/projects';
 import ProjectDescriptionChanges from '@/utils/ProjectDescriptionChanges';
 import { unnnicToastManager } from '@weni/unnnic-system';
 
@@ -15,6 +16,28 @@ export const AVAILABLE_LANGUAGES = [
   { value: 'pt-br', label: 'Português (Brasil)' },
 ];
 
+let currenciesPromise = null;
+
+function fetchCurrencies() {
+  if (!currenciesPromise) {
+    currenciesPromise = projects
+      .getCurrencies()
+      .then(({ data }) =>
+        (data.currencies || []).map((code) => ({ value: code, label: code })),
+      )
+      .catch((error) => {
+        currenciesPromise = null;
+        throw error;
+      });
+  }
+
+  return currenciesPromise;
+}
+
+export function resetCurrencyOptionsCache() {
+  currenciesPromise = null;
+}
+
 export function useProjectSettings() {
   const store = useStore();
   const { t } = useI18n();
@@ -24,6 +47,8 @@ export function useProjectSettings() {
   const description = ref('');
   const timezone = ref('');
   const language = ref(DEFAULT_LANGUAGE);
+  const currency = ref('');
+  const currencyOptions = ref([]);
 
   const currentProject = computed(() => store.getters.currentProject);
   const currentOrg = computed(() => store.getters.currentOrg);
@@ -72,12 +97,29 @@ export function useProjectSettings() {
     languageOptions.value.find(({ value }) => value === language.value),
   );
 
+  const selectedCurrency = computed(() =>
+    currencyOptions.value.find(({ value }) => value === currency.value),
+  );
+
+  function loadCurrencyOptions() {
+    fetchCurrencies()
+      .then((options) => {
+        currencyOptions.value = options;
+      })
+      .catch(() => {
+        currencyOptions.value = [];
+      });
+  }
+
+  loadCurrencyOptions();
+
   function initializeFromProject(project) {
     if (project) {
       name.value = project.name || '';
       description.value = project.description || '';
       timezone.value = project.timezone || '';
       language.value = project.language || DEFAULT_LANGUAGE;
+      currency.value = project.currency || '';
     }
   }
 
@@ -90,7 +132,8 @@ export function useProjectSettings() {
       name.value !== (originalProject.name || '') ||
       description.value !== (originalProject.description || '') ||
       timezone.value !== (originalProject.timezone || '') ||
-      language.value !== originalLanguage
+      language.value !== originalLanguage ||
+      currency.value !== (originalProject.currency || '')
     );
   }
 
@@ -112,13 +155,14 @@ export function useProjectSettings() {
         description: description.value,
         timezone: timezone.value,
         language: languageToSave,
+        currency: currency.value || null,
       });
 
-      // Sync all fields from server response to ensure local state matches backend
       name.value = response.data.name;
       description.value = response.data.description || '';
       timezone.value = response.data.timezone || '';
       language.value = response.data.language || DEFAULT_LANGUAGE;
+      currency.value = response.data.currency || '';
 
       ProjectDescriptionChanges.register({
         projectUuid,
@@ -133,6 +177,7 @@ export function useProjectSettings() {
           description: response.data.description || '',
           timezone: response.data.timezone || '',
           language: response.data.language || DEFAULT_LANGUAGE,
+          currency: response.data.currency || '',
         });
       }
     } catch (error) {
@@ -151,6 +196,7 @@ export function useProjectSettings() {
     description,
     timezone,
     language,
+    currency,
     currentProject,
     currentOrg,
     timezones,
@@ -158,6 +204,8 @@ export function useProjectSettings() {
     selectedTimezone,
     languageOptions,
     selectedLanguage,
+    currencyOptions,
+    selectedCurrency,
     initializeFromProject,
     hasChanges,
     isSaveDisabled,

--- a/src/composables/useProjectSettings.js
+++ b/src/composables/useProjectSettings.js
@@ -108,6 +108,7 @@ export function useProjectSettings() {
       })
       .catch(() => {
         currencyOptions.value = [];
+        unnnicToastManager.error(t('settings.workspace.currency_load_error'));
       });
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1630,6 +1630,7 @@
       "description": "Manage project preferences",
       "description_multi_agents": "Manage project preferences and credentials used by agents",
       "currency": "Currency",
+      "currency_load_error": "Currency options couldn't be loaded due to a technical issue",
       "language": "Language",
       "project_details": "Project details",
       "tabs": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1629,6 +1629,7 @@
       "title": "Workspace",
       "description": "Manage project preferences",
       "description_multi_agents": "Manage project preferences and credentials used by agents",
+      "currency": "Currency",
       "language": "Language",
       "project_details": "Project details",
       "tabs": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1629,6 +1629,7 @@
       "title": "Workspace",
       "description": "Gestionar preferencias del proyecto",
       "description_multi_agents": "Gestionar las preferencias del proyecto y las credenciales utilizadas por los agentes",
+      "currency": "Moneda",
       "language": "Idioma",
       "project_details": "Detalles del proyecto",
       "tabs": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1630,6 +1630,7 @@
       "description": "Gestionar preferencias del proyecto",
       "description_multi_agents": "Gestionar las preferencias del proyecto y las credenciales utilizadas por los agentes",
       "currency": "Moneda",
+      "currency_load_error": "No se pudieron cargar las opciones de moneda debido a un problema técnico",
       "language": "Idioma",
       "project_details": "Detalles del proyecto",
       "tabs": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1630,6 +1630,7 @@
       "description": "Gerencie as preferências do projeto",
       "description_multi_agents": "Gerencie as preferências do projeto e as credenciais usadas pelos agentes",
       "currency": "Moeda",
+      "currency_load_error": "Não foi possível carregar as opções de moeda devido a um problema técnico",
       "language": "Idioma",
       "project_details": "Detalhes do projeto",
       "tabs": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1629,6 +1629,7 @@
       "title": "Workspace",
       "description": "Gerencie as preferências do projeto",
       "description_multi_agents": "Gerencie as preferências do projeto e as credenciais usadas pelos agentes",
+      "currency": "Moeda",
       "language": "Idioma",
       "project_details": "Detalhes do projeto",
       "tabs": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1630,6 +1630,7 @@
       "description": "Gestionează preferințele proiectului",
       "description_multi_agents": "Gestionează preferințele proiectului și acreditările folosite de agenți",
       "currency": "Monedă",
+      "currency_load_error": "Nu s-au putut încărca opțiunile de monedă din cauza unei probleme tehnice",
       "language": "Language",
       "project_details": "Detalii proiect",
       "tabs": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1629,6 +1629,7 @@
       "title": "Spațiu de lucru",
       "description": "Gestionează preferințele proiectului",
       "description_multi_agents": "Gestionează preferințele proiectului și acreditările folosite de agenți",
+      "currency": "Monedă",
       "language": "Language",
       "project_details": "Detalii proiect",
       "tabs": {

--- a/src/store/project/actions.js
+++ b/src/store/project/actions.js
@@ -86,16 +86,25 @@ export default {
 
   editProject(
     store,
-    { name, organization, projectUuid, timezone, description, language },
-  ) {
-    return projects.editProject(
+    {
       name,
       organization,
       projectUuid,
       timezone,
       description,
       language,
-    );
+      currency,
+    },
+  ) {
+    return projects.editProject({
+      name,
+      organization,
+      projectUuid,
+      timezone,
+      description,
+      language,
+      currency,
+    });
   },
 
   deleteProject(store, { uuid }) {
@@ -110,6 +119,7 @@ export default {
       description,
       timezone,
       language,
+      currency,
       menu = {
         chat: [],
         flows: '',
@@ -138,6 +148,7 @@ export default {
       description,
       timezone,
       language,
+      currency,
       menu,
       organization,
       flow_organization,

--- a/src/views/settings/ProjectPreferences.vue
+++ b/src/views/settings/ProjectPreferences.vue
@@ -22,16 +22,29 @@
         />
       </UnnnicFormElement>
 
-      <UnnnicFormElement :label="$t('settings.workspace.language')">
-        <UnnnicSelect
-          :modelValue="language"
-          :options="languageOptions"
-          enableSearch
-          :search="languageSearch"
-          @update:search="languageSearch = $event"
-          @update:model-value="language = $event"
-        />
-      </UnnnicFormElement>
+      <div class="project-preferences__row">
+        <UnnnicFormElement :label="$t('settings.workspace.language')">
+          <UnnnicSelect
+            :modelValue="language"
+            :options="languageOptions"
+            enableSearch
+            :search="languageSearch"
+            @update:search="languageSearch = $event"
+            @update:model-value="language = $event"
+          />
+        </UnnnicFormElement>
+
+        <UnnnicFormElement :label="$t('settings.workspace.currency')">
+          <UnnnicSelect
+            :modelValue="currency"
+            :options="currencyOptions"
+            enableSearch
+            :search="currencySearch"
+            @update:search="currencySearch = $event"
+            @update:model-value="currency = $event"
+          />
+        </UnnnicFormElement>
+      </div>
     </div>
 
     <UnnnicModalDialog
@@ -73,8 +86,10 @@ const {
   description,
   timezone,
   language,
+  currency,
   timezoneOptions,
   languageOptions,
+  currencyOptions,
   initializeFromProject,
   hasChanges,
   isSaveDisabled,
@@ -85,6 +100,7 @@ const currentProject = computed(() => store.getters.currentProject);
 
 const timezoneSearch = ref('');
 const languageSearch = ref('');
+const currencySearch = ref('');
 
 const descriptionError = computed(() =>
   !description.value ? t('errors.required') : false,
@@ -117,6 +133,7 @@ async function handleSave() {
         description: data.description,
         timezone: data.timezone,
         language: data.language,
+        currency: data.currency,
       });
     },
   });
@@ -135,6 +152,7 @@ async function saveAndLeave() {
         description: data.description,
         timezone: data.timezone,
         language: data.language,
+        currency: data.currency,
       });
 
       showUnsavedChangesModal.value = false;
@@ -206,6 +224,17 @@ onMounted(() => {
     display: flex;
     flex-direction: column;
     gap: $unnnic-space-4;
+  }
+
+  &__row {
+    display: flex;
+    gap: $unnnic-space-4;
+    align-items: flex-start;
+
+    > * {
+      flex: 1;
+      min-width: 0;
+    }
   }
 }
 </style>

--- a/tests/unit/unit/components/common/RightBar/ProjectSettings.spec.js
+++ b/tests/unit/unit/components/common/RightBar/ProjectSettings.spec.js
@@ -19,6 +19,9 @@ vi.mock('@/store/featureFlags', () => ({
 vi.mock('@/api/projects', () => ({
   default: {
     updateModeProject: vi.fn(),
+    getCurrencies: vi.fn().mockResolvedValue({
+      data: { currencies: ['BRL', 'USD', 'EUR'] },
+    }),
   },
 }));
 
@@ -46,6 +49,7 @@ describe('ProjectSettings.vue', () => {
     projectDescription: project.description || 'Test description',
     projectTimezone: project.timezone,
     projectLanguage: project.language || 'en-us',
+    projectCurrency: project.currency || 'BRL',
     authorizations: [],
     pendingAuthorizations: [],
     hasChat: false,
@@ -59,6 +63,7 @@ describe('ProjectSettings.vue', () => {
           description: 'Updated description',
           timezone: 'America/Sao_Paulo',
           language: 'pt-br',
+          currency: 'BRL',
         },
       }),
     };
@@ -108,6 +113,7 @@ describe('ProjectSettings.vue', () => {
       expect(wrapper.vm.description).toBe(defaultProps.projectDescription);
       expect(wrapper.vm.timezone).toBe(defaultProps.projectTimezone);
       expect(wrapper.vm.language).toBe(defaultProps.projectLanguage);
+      expect(wrapper.vm.currency).toBe(defaultProps.projectCurrency);
     });
 
     it('should render the component', () => {
@@ -162,6 +168,7 @@ describe('ProjectSettings.vue', () => {
           description: defaultProps.projectDescription,
           timezone: defaultProps.projectTimezone,
           language: defaultProps.projectLanguage,
+          currency: defaultProps.projectCurrency,
         }),
       );
     });
@@ -178,6 +185,7 @@ describe('ProjectSettings.vue', () => {
         description: 'Updated description',
         timezone: 'America/Sao_Paulo',
         language: 'pt-br',
+        currency: 'BRL',
       });
     });
   });
@@ -213,6 +221,20 @@ describe('ProjectSettings.vue', () => {
         value: 'pt-br',
         label: 'Português (Brasil)',
       });
+    });
+  });
+
+  describe('currency field', () => {
+    it('should include currency in form data', () => {
+      expect(wrapper.vm.currency).toBeDefined();
+      expect(wrapper.vm.currencyOptions).toBeDefined();
+      expect(wrapper.vm.currency).toBe('BRL');
+    });
+
+    it('should be enabled when currency is changed', async () => {
+      wrapper.vm.currency = 'USD';
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.isSaveButtonDisabled).toBe(false);
     });
   });
 });

--- a/tests/unit/unit/composables/useProjectSettings.spec.js
+++ b/tests/unit/unit/composables/useProjectSettings.spec.js
@@ -4,7 +4,9 @@ import {
   useProjectSettings,
   AVAILABLE_LANGUAGES,
   DEFAULT_LANGUAGE,
+  resetCurrencyOptionsCache,
 } from '@/composables/useProjectSettings';
+import projects from '@/api/projects';
 
 // Mock vue-i18n
 vi.mock('vue-i18n', () => ({
@@ -24,6 +26,7 @@ const mockStore = {
       description: 'Test description',
       timezone: 'America/Sao_Paulo',
       language: 'en-us',
+      currency: 'BRL',
     },
     currentOrg: {
       uuid: 'org-123',
@@ -34,6 +37,14 @@ const mockStore = {
 
 vi.mock('vuex', () => ({
   useStore: () => mockStore,
+}));
+
+vi.mock('@/api/projects', () => ({
+  default: {
+    getCurrencies: vi.fn().mockResolvedValue({
+      data: { currencies: ['BRL', 'USD', 'EUR'] },
+    }),
+  },
 }));
 
 // Mock unnnicToastManager
@@ -91,7 +102,11 @@ vi.mock('@/assets/countries', () => ({
 describe('useProjectSettings', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    resetCurrencyOptionsCache();
     vi.clearAllMocks();
+    projects.getCurrencies.mockResolvedValue({
+      data: { currencies: ['BRL', 'USD', 'EUR'] },
+    });
   });
 
   afterEach(() => {
@@ -116,7 +131,7 @@ describe('useProjectSettings', () => {
 
   describe('initial state', () => {
     it('should return initial state with default language', () => {
-      const { loading, name, description, timezone, language } =
+      const { loading, name, description, timezone, language, currency } =
         useProjectSettings();
 
       expect(loading.value).toBe(false);
@@ -124,6 +139,7 @@ describe('useProjectSettings', () => {
       expect(description.value).toBe('');
       expect(timezone.value).toBe('');
       expect(language.value).toBe(DEFAULT_LANGUAGE);
+      expect(currency.value).toBe('');
     });
 
     it('should return computed properties', () => {
@@ -139,14 +155,21 @@ describe('useProjectSettings', () => {
 
   describe('initializeFromProject', () => {
     it('should initialize form values from project', () => {
-      const { name, description, timezone, language, initializeFromProject } =
-        useProjectSettings();
+      const {
+        name,
+        description,
+        timezone,
+        language,
+        currency,
+        initializeFromProject,
+      } = useProjectSettings();
 
       const project = {
         name: 'Test Project',
         description: 'Test description',
         timezone: 'America/Sao_Paulo',
         language: 'pt-br',
+        currency: 'BRL',
       };
 
       initializeFromProject(project);
@@ -155,6 +178,7 @@ describe('useProjectSettings', () => {
       expect(description.value).toBe('Test description');
       expect(timezone.value).toBe('America/Sao_Paulo');
       expect(language.value).toBe('pt-br');
+      expect(currency.value).toBe('BRL');
     });
 
     it('should handle null project and keep default language', () => {
@@ -298,20 +322,20 @@ describe('useProjectSettings', () => {
       expect(hasChanges(project)).toBe(false);
     });
 
-    it('should detect change when language differs from default', () => {
-      const { language, hasChanges, initializeFromProject } =
+    it('should detect change when currency differs', () => {
+      const { currency, hasChanges, initializeFromProject } =
         useProjectSettings();
 
-      // Project without language
       const project = {
         name: 'Test Project',
         description: 'Test description',
         timezone: 'America/Sao_Paulo',
-        // language is undefined, defaults to 'en-us'
+        language: 'en-us',
+        currency: 'BRL',
       };
 
       initializeFromProject(project);
-      language.value = 'pt-br';
+      currency.value = 'USD';
 
       expect(hasChanges(project)).toBe(true);
     });
@@ -427,6 +451,7 @@ describe('useProjectSettings', () => {
         description: 'Test description',
         timezone: 'America/Sao_Paulo',
         language: 'en-us',
+        currency: null,
       });
     });
 
@@ -476,6 +501,7 @@ describe('useProjectSettings', () => {
         description: 'Test description',
         timezone: 'America/Sao_Paulo',
         language: DEFAULT_LANGUAGE,
+        currency: null,
       });
     });
 
@@ -485,6 +511,7 @@ describe('useProjectSettings', () => {
         description,
         timezone,
         language,
+        currency,
         saveProject,
         initializeFromProject,
       } = useProjectSettings();
@@ -504,6 +531,7 @@ describe('useProjectSettings', () => {
           description: 'Server Updated Description',
           timezone: 'America/New_York',
           language: 'pt-br',
+          currency: 'USD',
         },
       });
 
@@ -516,6 +544,7 @@ describe('useProjectSettings', () => {
       expect(description.value).toBe('Server Updated Description');
       expect(timezone.value).toBe('America/New_York');
       expect(language.value).toBe('pt-br');
+      expect(currency.value).toBe('USD');
     });
 
     it('should call onSuccess callback with server response data', async () => {
@@ -535,6 +564,7 @@ describe('useProjectSettings', () => {
         description: 'Updated description',
         timezone: 'America/Sao_Paulo',
         language: 'pt-br',
+        currency: 'EUR',
       };
 
       mockDispatch.mockResolvedValue({ data: responseData });
@@ -551,6 +581,7 @@ describe('useProjectSettings', () => {
         description: responseData.description,
         timezone: responseData.timezone,
         language: responseData.language,
+        currency: responseData.currency,
       });
     });
 
@@ -629,6 +660,50 @@ describe('useProjectSettings', () => {
       language.value = 'unknown';
 
       expect(selectedLanguage.value).toBeUndefined();
+    });
+  });
+
+  describe('currency options', () => {
+    it('should load currency options from the API', async () => {
+      const { currencyOptions } = useProjectSettings();
+
+      await vi.waitFor(() => {
+        expect(currencyOptions.value).toEqual([
+          { value: 'BRL', label: 'BRL' },
+          { value: 'USD', label: 'USD' },
+          { value: 'EUR', label: 'EUR' },
+        ]);
+      });
+    });
+
+    it('should include currency in the save payload', async () => {
+      const { currency, saveProject, initializeFromProject } =
+        useProjectSettings();
+
+      const project = {
+        name: 'Test Project',
+        description: 'Test description',
+        timezone: 'America/Sao_Paulo',
+        language: 'en-us',
+        currency: 'BRL',
+      };
+
+      initializeFromProject(project);
+      currency.value = 'USD';
+
+      mockDispatch.mockResolvedValue({
+        data: { ...project, currency: 'USD' },
+      });
+
+      await saveProject({
+        projectUuid: 'project-123',
+        onSuccess: vi.fn(),
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        'editProject',
+        expect.objectContaining({ currency: 'USD' }),
+      );
     });
   });
 });

--- a/tests/unit/unit/composables/useProjectSettings.spec.js
+++ b/tests/unit/unit/composables/useProjectSettings.spec.js
@@ -7,6 +7,7 @@ import {
   resetCurrencyOptionsCache,
 } from '@/composables/useProjectSettings';
 import projects from '@/api/projects';
+import { unnnicToastManager } from '@weni/unnnic-system';
 
 // Mock vue-i18n
 vi.mock('vue-i18n', () => ({
@@ -673,6 +674,19 @@ describe('useProjectSettings', () => {
           { value: 'USD', label: 'USD' },
           { value: 'EUR', label: 'EUR' },
         ]);
+      });
+    });
+
+    it('should show a toast when currency options fail to load', async () => {
+      projects.getCurrencies.mockRejectedValue(new Error('network'));
+
+      const { currencyOptions } = useProjectSettings();
+
+      await vi.waitFor(() => {
+        expect(currencyOptions.value).toEqual([]);
+        expect(unnnicToastManager.error).toHaveBeenCalledWith(
+          'settings.workspace.currency_load_error',
+        );
       });
     });
 

--- a/tests/unit/unit/views/settings/ProjectPreferences.spec.js
+++ b/tests/unit/unit/views/settings/ProjectPreferences.spec.js
@@ -14,6 +14,14 @@ vi.mock('@/utils/ProjectDescriptionChanges', () => ({
   },
 }));
 
+vi.mock('@/api/projects', () => ({
+  default: {
+    getCurrencies: vi.fn().mockResolvedValue({
+      data: { currencies: ['BRL', 'USD', 'EUR'] },
+    }),
+  },
+}));
+
 describe('ProjectPreferences.vue', () => {
   let wrapper;
   let store;
@@ -28,6 +36,7 @@ describe('ProjectPreferences.vue', () => {
     description: 'Test description',
     timezone: 'America/Sao_Paulo',
     language: 'en-us',
+    currency: 'BRL',
   };
 
   beforeEach(() => {
@@ -38,6 +47,7 @@ describe('ProjectPreferences.vue', () => {
           description: 'Updated description',
           timezone: 'America/New_York',
           language: 'pt-br',
+          currency: 'USD',
         },
       }),
     };
@@ -88,6 +98,7 @@ describe('ProjectPreferences.vue', () => {
       expect(wrapper.vm.description).toBe(mockProject.description);
       expect(wrapper.vm.timezone).toBe(mockProject.timezone);
       expect(wrapper.vm.language).toBe(mockProject.language);
+      expect(wrapper.vm.currency).toBe(mockProject.currency);
     });
   });
 
@@ -190,6 +201,7 @@ describe('ProjectPreferences.vue', () => {
           description: mockProject.description,
           timezone: mockProject.timezone,
           language: mockProject.language,
+          currency: mockProject.currency,
         }),
       );
     });
@@ -207,6 +219,7 @@ describe('ProjectPreferences.vue', () => {
           description: 'Updated description',
           timezone: 'America/New_York',
           language: 'pt-br',
+          currency: 'USD',
         }),
       );
     });
@@ -231,6 +244,19 @@ describe('ProjectPreferences.vue', () => {
     it('should correctly select current language', () => {
       expect(wrapper.vm.language).toBeDefined();
       expect(wrapper.vm.language).toBe('en-us');
+    });
+  });
+
+  describe('currency field', () => {
+    it('should initialize currency from currentProject', () => {
+      expect(wrapper.vm.currency).toBe('BRL');
+      expect(wrapper.vm.currencyOptions).toBeDefined();
+    });
+
+    it('should be enabled when currency is changed', async () => {
+      wrapper.vm.currency = 'USD';
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.isSaveButtonDisabled).toBe(false);
     });
   });
 


### PR DESCRIPTION
### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why
Projects need to support a configurable currency field so that agents and project settings can reflect the correct monetary context for each workspace.

### What Changed
- Added a `GET /v2/currencies` API call to fetch available currency options, with a module-level promise cache to avoid redundant requests.
- Extended `editProject` in the API, store actions, and composable to accept and persist a `currency` field.
- Added a `currency` reactive ref to `useProjectSettings`, initialized from the project data and included in save payloads and server response syncing.
- Rendered a searchable currency `UnnnicSelect` dropdown in both the `ProjectPreferences` view (side-by-side with the language selector) and the `ProjectSettings` right bar panel.
- Propagated `projectCurrency` as a prop through `RightBar`, `ProjectListItem`, and `ProjectList`, ensuring the local project object is updated on save.
- Added `currency` translations under `settings.workspace.currency` for English, Spanish, Portuguese (BR), and Romanian locales.
- Added and updated unit tests for the composable, `ProjectSettings`, and `ProjectPreferences` to cover currency initialization, change detection, save payload inclusion, and API loading behavior.