### PR TITLE
refactor: migrate user management from Vuex to Pinia

### DIFF
--- a/src/components/orgs/UserManagement.vue
+++ b/src/components/orgs/UserManagement.vue
@@ -81,7 +81,7 @@
 
 <script>
 import { mapActions } from 'vuex';
-import { mapState } from 'pinia';
+import { mapState, mapActions as mapPiniaActions } from 'pinia';
 import OrgRole from './orgRole.vue';
 import InfiniteLoading from '../InfiniteLoading.vue';
 import Unnnic from '@weni/unnnic-system';
@@ -90,6 +90,7 @@ import orgs from '../../api/orgs';
 import SearchUser from './searchUser.vue';
 import OrgUserRoleSelect from './OrgUserRoleSelect.vue';
 import { useAccountStore } from '@/store/account';
+import { useUsersStore } from '@/store/users';
 
 export default {
   components: {
@@ -178,12 +179,8 @@ export default {
   mounted() {},
 
   methods: {
-    ...mapActions([
-      'searchUsers',
-      'leaveOrg',
-      'removeAuthorization',
-      'openModal',
-    ]),
+    ...mapActions(['leaveOrg', 'removeAuthorization', 'openModal']),
+    ...mapPiniaActions(useUsersStore, ['searchUsers']),
 
     capitalize: _.capitalize,
 

--- a/src/components/orgs/searchUser.vue
+++ b/src/components/orgs/searchUser.vue
@@ -16,7 +16,8 @@
 
 <script>
 import { debounce } from 'lodash';
-import { mapActions } from 'vuex';
+import { mapActions } from 'pinia';
+import { useUsersStore } from '@/store/users';
 
 export default {
   name: 'SearchUser',
@@ -51,7 +52,7 @@ export default {
     }, 300);
   },
   methods: {
-    ...mapActions(['searchUsers']),
+    ...mapActions(useUsersStore, ['searchUsers']),
     handleSearch(value) {
       this.search = value;
       this.debouncedSearch();

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,6 @@
 import { createStore } from 'vuex';
 import Org from './org';
 import Billing from './billing';
-import Users from './users';
 import Project from './project';
 import Modal from './modal';
 import BillingSteps from './billingSteps';
@@ -11,7 +10,6 @@ const store = createStore({
   modules: {
     Org,
     Billing,
-    Users,
     Project,
     Modal,
     BillingSteps,

--- a/src/store/users/__tests__/users.spec.js
+++ b/src/store/users/__tests__/users.spec.js
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useUsersStore } from '@/store/users';
+import usersApi from '@/api/users';
+
+vi.mock('@/api/users', () => ({
+  default: {
+    search: vi.fn(),
+  },
+}));
+
+describe('useUsersStore', () => {
+  let usersStore;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    usersStore = useUsersStore();
+    vi.clearAllMocks();
+  });
+
+  describe('searchUsers', () => {
+    it('calls the search API with the given term and returns the response', async () => {
+      const response = { data: [{ email: 'jane@example.com' }] };
+      usersApi.search.mockResolvedValue(response);
+
+      const result = await usersStore.searchUsers({ search: 'jane' });
+
+      expect(usersApi.search).toHaveBeenCalledWith('jane');
+      expect(result).toBe(response);
+    });
+
+    it('propagates API errors', async () => {
+      const error = new Error('search failed');
+      usersApi.search.mockRejectedValue(error);
+
+      await expect(usersStore.searchUsers({ search: 'jane' })).rejects.toThrow(
+        error,
+      );
+
+      expect(usersApi.search).toHaveBeenCalledWith('jane');
+    });
+  });
+});

--- a/src/store/users/actions.js
+++ b/src/store/users/actions.js
@@ -1,7 +1,0 @@
-import users from '../../api/users';
-
-export default {
-  searchUsers(store, { search }) {
-    return users.search(search);
-  },
-};

--- a/src/store/users/index.js
+++ b/src/store/users/index.js
@@ -1,5 +1,12 @@
-import actions from './actions';
+import { defineStore } from 'pinia';
+import users from '@/api/users';
 
-export default {
-  actions,
-};
+export const useUsersStore = defineStore('users', () => {
+  function searchUsers({ search }) {
+    return users.search(search);
+  }
+
+  return {
+    searchUsers,
+  };
+});

--- a/tests/unit/unit/components/orgs/searchUser.spec.js
+++ b/tests/unit/unit/components/orgs/searchUser.spec.js
@@ -1,25 +1,17 @@
 import { vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
 import SearchUser from '@/components/orgs/searchUser.vue';
-import { createStore } from 'vuex';
+import { useUsersStore } from '@/store/users';
 
 describe('SearchUser.vue', () => {
   let wrapper;
-  let actions;
-  let store;
+  let usersStore;
 
   beforeEach(() => {
-    actions = {
-      searchUsers: vi.fn(),
-    };
-
-    store = createStore({
-      actions,
-    });
-
     wrapper = shallowMount(SearchUser, {
       global: {
-        plugins: [store],
+        plugins: [createTestingPinia()],
         stubs: {
           UnnnicAutocomplete: true,
           UnnnicFormElement: true,
@@ -27,6 +19,8 @@ describe('SearchUser.vue', () => {
         },
       },
     });
+
+    usersStore = useUsersStore();
   });
 
   it('renders a snapshot', () => {
@@ -57,7 +51,7 @@ describe('SearchUser.vue', () => {
         search: 'test@a.com',
       });
 
-      actions.searchUsers.mockImplementation(() => {
+      usersStore.searchUsers.mockImplementation(() => {
         throw new Error('error fetching');
       });
       await wrapper.vm.fetchUsers();
@@ -68,9 +62,9 @@ describe('SearchUser.vue', () => {
       wrapper.setData({
         search: 'test@a.com',
       });
-      expect(actions.searchUsers).not.toHaveBeenCalled();
+      expect(usersStore.searchUsers).not.toHaveBeenCalled();
       await wrapper.vm.fetchUsers();
-      expect(actions.searchUsers).toHaveBeenCalledTimes(1);
+      expect(usersStore.searchUsers).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
### Type of Change
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Tests
- [ ] Chore
- [ ] Locales

### Why
The `Users` store was previously a Vuex module, which is inconsistent with the ongoing migration toward Pinia. Moving it to Pinia improves consistency across the store layer and allows components to consume it using Pinia's `mapActions`.

### What Changed
- Converted the `Users` Vuex module into a Pinia store (`useUsersStore`) using the Composition API style (`defineStore` with a setup function).
- Removed the `Users` module from the Vuex store registration.
- Updated `UserManagement.vue` to import `mapActions` from Pinia and bind `searchUsers` from `useUsersStore`.
- Updated `searchUser.vue` to use `mapActions` from Pinia with `useUsersStore` instead of Vuex.
- Added unit tests for `useUsersStore` covering successful search calls and API error propagation.
- Updated the `searchUser.spec.js` tests to use `createTestingPinia` and interact with the Pinia store instead of a mocked Vuex store.