### PR TITLE
refactor: migrate RightBar management from Vuex to Pinia

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -125,7 +125,7 @@
       />
 
       <RightBar
-        v-for="rightBar in $store.state.RightBar.all"
+        v-for="rightBar in rightBarStore.all"
         v-bind="rightBar.props"
         :id="rightBar.id"
         :key="`right-bar-${rightBar.id}`"
@@ -187,6 +187,7 @@ import { useChatsThemeStore, CHATS_THEME_DARK } from './store/chatsTheme.js';
 import { buildChatsHostRedirectRoute } from '@/utils/normalizeInternalPath';
 import { useThemeStore } from '@/store/theme';
 import { useNewsStore } from '@/store/news';
+import { useRightBarStore } from '@/store/RightBar';
 
 const CHATS_DARK_ROUTES = new Set(['chats']);
 const CHATS_LIGHT_ROUTES = new Set(['settingsChats']);
@@ -238,11 +239,13 @@ export default {
     const chatsThemeStore = useChatsThemeStore();
     const themeStore = useThemeStore();
     const newsStore = useNewsStore();
+    const rightBarStore = useRightBarStore();
     return {
       featureFlagsStore,
       chatsThemeStore,
       themeStore,
       newsStore,
+      rightBarStore,
     };
   },
 

--- a/src/components/ExternalSystem.vue
+++ b/src/components/ExternalSystem.vue
@@ -30,11 +30,12 @@
 <script>
 import sendAllIframes from '../utils/plugins/sendAllIframes';
 import { mapGetters } from 'vuex';
-import { mapState } from 'pinia';
+import { mapState, mapActions as mapPiniaActions } from 'pinia';
 import { get } from 'lodash';
 import getEnv from '../utils/env';
 import ProjectDescriptionChanges from '../utils/ProjectDescriptionChanges';
 import { useAccountStore } from '@/store/account';
+import { useRightBarStore } from '@/store/RightBar';
 
 export default {
   // eslint-disable-next-line vue/multi-word-component-names
@@ -292,6 +293,7 @@ export default {
   },
 
   methods: {
+    ...mapPiniaActions(useRightBarStore, ['openRightBar']),
     openEditProject() {
       const project = this.$store.state.Project.projects
         .map(({ data }) => data)
@@ -300,7 +302,7 @@ export default {
 
       const projectUuid = project.uuid;
 
-      this.$store.dispatch('openRightBar', {
+      this.openRightBar({
         props: {
           type: 'ProjectSettings',
           projectUuid,

--- a/src/components/Topbar/Topbar.vue
+++ b/src/components/Topbar/Topbar.vue
@@ -58,6 +58,7 @@ import WarningTrialChip from '@/components/billing/WarningTrialChip.vue';
 import ProfileDropdown from './ProfileDropdown.vue';
 import i18n from '../../utils/plugins/i18n';
 import { useNewsStore } from '@/store/news';
+import { useRightBarStore } from '@/store/RightBar';
 
 defineEmits(['openModalTrialPeriod']);
 
@@ -65,6 +66,7 @@ const instance = getCurrentInstance();
 
 const store = instance.proxy['$store'];
 const newsStore = useNewsStore();
+const rightBarStore = useRightBarStore();
 
 const hasUpdates = computed(() => {
   const userLastViewedMonth = newsStore.lastViewedNews;
@@ -95,7 +97,7 @@ const shouldShowTopbarLogo = computed(() => {
 });
 
 function openLearningCenter() {
-  store.dispatch('openRightBar', {
+  rightBarStore.openRightBar({
     props: {
       type: 'LearningCenter',
     },
@@ -103,7 +105,7 @@ function openLearningCenter() {
 }
 
 function openNotifications() {
-  store.dispatch('openRightBar', {
+  rightBarStore.openRightBar({
     props: {
       type: 'Notifications',
       orgUuid: store.getters.currentOrg?.uuid,

--- a/src/components/common/RightBar/Index.vue
+++ b/src/components/common/RightBar/Index.vue
@@ -148,6 +148,8 @@ import Notifications from './Notifications.vue';
 import ProjectSettings from './ProjectSettings.vue';
 import LearningCenter from './LearningCenter.vue';
 import { mapActions } from 'vuex';
+import { mapActions as mapPiniaActions } from 'pinia';
+import { useRightBarStore } from '@/store/RightBar';
 
 export default {
   components: {
@@ -277,6 +279,7 @@ export default {
 
   methods: {
     ...mapActions(['removeOrgFromList']),
+    ...mapPiniaActions(useRightBarStore, ['closeRightBar']),
     close() {
       if (this.type === 'manage-members') {
         this.props?.onFinished?.();
@@ -285,7 +288,7 @@ export default {
       this.isClosed = true;
 
       setTimeout(() => {
-        this.$store.dispatch('closeRightBar', this.id);
+        this.closeRightBar(this.id);
       }, 200);
     },
     onUpdateProject(data) {

--- a/src/components/orgs/orgList.vue
+++ b/src/components/orgs/orgList.vue
@@ -79,10 +79,11 @@
 <script>
 import OrgCard from './OrgCard.vue';
 import { mapActions, mapGetters } from 'vuex';
-import { mapState } from 'pinia';
+import { mapState, mapActions as mapPiniaActions } from 'pinia';
 import NewInfiniteLoading from '../NewInfiniteLoading.vue';
 import { isOrgAccessDisabled } from '@/utils/orgAccess';
 import { useAccountStore } from '@/store/account';
+import { useRightBarStore } from '@/store/RightBar';
 
 export default {
   // eslint-disable-next-line vue/multi-word-component-names
@@ -169,6 +170,7 @@ export default {
       'clearCurrentProject',
       'openModal',
     ]),
+    ...mapPiniaActions(useRightBarStore, ['openRightBar']),
 
     runIfOrgAccessible(org, callback) {
       if (isOrgAccessDisabled(org)) {
@@ -267,7 +269,7 @@ export default {
     },
     onEdit(org) {
       this.runIfOrgAccessible(org, () => {
-        this.$store.dispatch('openRightBar', {
+        this.openRightBar({
           props: {
             type: 'OrgSettings',
             orgUuid: org.uuid,
@@ -277,7 +279,7 @@ export default {
     },
     onEditPermissions(org) {
       this.runIfOrgAccessible(org, () => {
-        this.$store.dispatch('openRightBar', {
+        this.openRightBar({
           props: {
             type: 'OrgManageUsers',
             orgUuid: org.uuid,
@@ -287,7 +289,7 @@ export default {
     },
     onViewPermissions(org) {
       this.runIfOrgAccessible(org, () => {
-        this.$store.dispatch('openRightBar', {
+        this.openRightBar({
           props: {
             type: 'OrgReadUsers',
             orgUuid: org.uuid,

--- a/src/components/projects/ProjectListItem.vue
+++ b/src/components/projects/ProjectListItem.vue
@@ -39,7 +39,7 @@
           <UnnnicDropdownItem
             v-if="canManageMembers"
             @click="
-              $store.dispatch('openRightBar', {
+              openRightBar({
                 props: {
                   type: 'ProjectManageUsers',
                   projectUuid: project.uuid,
@@ -67,7 +67,7 @@
           <UnnnicDropdownItem
             v-if="canViewMembers"
             @click="
-              $store.dispatch('openRightBar', {
+              openRightBar({
                 props: {
                   type: 'ProjectReadUsers',
                   projectUuid: project.uuid,
@@ -104,6 +104,8 @@ import {
   PROJECT_ROLE_MARKETING,
 } from '../users/permissionsObjects';
 import { get } from 'lodash';
+import { mapActions as mapPiniaActions } from 'pinia';
+import { useRightBarStore } from '@/store/RightBar';
 export default {
   name: 'ProjectListItem',
 
@@ -219,12 +221,13 @@ export default {
   },
 
   methods: {
+    ...mapPiniaActions(useRightBarStore, ['openRightBar']),
     openEditProject() {
       if (!this.canManageMembers) {
         return;
       }
 
-      this.$store.dispatch('openRightBar', {
+      this.openRightBar({
         props: {
           type: 'ProjectSettings',
           projectUuid: this.project.uuid,

--- a/src/store/RightBar/__tests__/rightBar.spec.js
+++ b/src/store/RightBar/__tests__/rightBar.spec.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useRightBarStore } from '@/store/RightBar';
+
+describe('useRightBarStore', () => {
+  let rightBarStore;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    rightBarStore = useRightBarStore();
+  });
+
+  describe('initial state', () => {
+    it('exposes the default state', () => {
+      expect(rightBarStore.lastInsertedId).toBe(0);
+      expect(rightBarStore.all).toEqual([]);
+    });
+  });
+
+  describe('openRightBar', () => {
+    it('assigns an incremental id, mutates the payload, and appends it', () => {
+      const first = { props: { type: 'Notifications' } };
+      const second = { props: { type: 'LearningCenter' } };
+
+      const firstId = rightBarStore.openRightBar(first);
+      const secondId = rightBarStore.openRightBar(second);
+
+      expect(firstId).toBe(1);
+      expect(secondId).toBe(2);
+      expect(first.id).toBe(1);
+      expect(second.id).toBe(2);
+      expect(rightBarStore.lastInsertedId).toBe(2);
+      expect(rightBarStore.all).toEqual([first, second]);
+    });
+  });
+
+  describe('closeRightBar', () => {
+    it('removes the matching entry and returns a promise', async () => {
+      const first = { props: { type: 'Notifications' } };
+      const second = { props: { type: 'LearningCenter' } };
+
+      const firstId = rightBarStore.openRightBar(first);
+      const secondId = rightBarStore.openRightBar(second);
+
+      await expect(
+        rightBarStore.closeRightBar(firstId),
+      ).resolves.toBeUndefined();
+
+      expect(rightBarStore.all).toEqual([second]);
+      expect(rightBarStore.all[0].id).toBe(secondId);
+      expect(rightBarStore.lastInsertedId).toBe(2);
+    });
+
+    it('leaves the list unchanged when the id is not present', async () => {
+      const payload = { props: { type: 'Notifications' } };
+      rightBarStore.openRightBar(payload);
+
+      await rightBarStore.closeRightBar(999);
+
+      expect(rightBarStore.all).toEqual([payload]);
+    });
+  });
+});

--- a/src/store/RightBar/index.js
+++ b/src/store/RightBar/index.js
@@ -1,39 +1,37 @@
 import { extend } from 'lodash';
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
 
-const state = {
-  lastInsertedId: 0,
-  all: [],
-};
+export const useRightBarStore = defineStore('RightBar', () => {
+  const lastInsertedId = ref(0);
+  const all = ref([]);
 
-const getters = {};
+  function OPEN_RIGHT_BAR(data) {
+    all.value.push(data);
+  }
 
-const actions = {
-  openRightBar({ commit, state }, data) {
-    extend(data, { id: ++state.lastInsertedId });
+  function CLOSE_RIGHT_BAR(id) {
+    all.value = all.value.filter((rightBar) => rightBar.id !== id);
+  }
 
-    commit('OPEN_RIGHT_BAR', data);
+  function openRightBar(data) {
+    extend(data, { id: ++lastInsertedId.value });
+
+    OPEN_RIGHT_BAR(data);
 
     return data.id;
-  },
+  }
 
-  async closeRightBar({ commit }, id) {
-    commit('CLOSE_RIGHT_BAR', id);
-  },
-};
+  async function closeRightBar(id) {
+    CLOSE_RIGHT_BAR(id);
+  }
 
-const mutations = {
-  OPEN_RIGHT_BAR: (state, data) => {
-    state.all.push(data);
-  },
-
-  CLOSE_RIGHT_BAR: (state, id) => {
-    state.all = state.all.filter((rightBar) => rightBar.id !== id);
-  },
-};
-
-export default {
-  state,
-  getters,
-  actions,
-  mutations,
-};
+  return {
+    lastInsertedId,
+    all,
+    OPEN_RIGHT_BAR,
+    CLOSE_RIGHT_BAR,
+    openRightBar,
+    closeRightBar,
+  };
+});

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,7 +4,6 @@ import Billing from './billing';
 import Project from './project';
 import Modal from './modal';
 import BillingSteps from './billingSteps';
-import RightBar from './RightBar';
 
 const store = createStore({
   modules: {
@@ -13,7 +12,6 @@ const store = createStore({
     Project,
     Modal,
     BillingSteps,
-    RightBar,
   },
 });
 

--- a/src/views/projects/projects.vue
+++ b/src/views/projects/projects.vue
@@ -120,7 +120,9 @@
 <script>
 import ProjectList from '../../components/projects/ProjectList.vue';
 import { mapGetters, mapActions } from 'vuex';
+import { mapActions as mapPiniaActions } from 'pinia';
 import ProjectLoading from '../loadings/projects.vue';
+import { useRightBarStore } from '@/store/RightBar';
 import { get } from 'lodash';
 import {
   ORG_ROLE_ADMIN,
@@ -214,9 +216,10 @@ export default {
 
   methods: {
     ...mapActions(['setCurrentProject']),
+    ...mapPiniaActions(useRightBarStore, ['openRightBar']),
 
     openManageMembers() {
-      this.$store.dispatch('openRightBar', {
+      this.openRightBar({
         props: {
           type: 'OrgManageUsers',
           orgUuid: this.currentOrg.uuid,
@@ -225,7 +228,7 @@ export default {
     },
 
     openViewMembers() {
-      this.$store.dispatch('openRightBar', {
+      this.openRightBar({
         props: {
           type: 'OrgViewUsers',
           orgUuid: this.currentOrg.uuid,

--- a/tests/unit/unit/components/orgs/orgList.spec.js
+++ b/tests/unit/unit/components/orgs/orgList.spec.js
@@ -28,7 +28,6 @@ describe('orgList.vue', () => {
       clearCurrentOrg: vi.fn(),
       clearCurrentProject: vi.fn(),
       openModal: vi.fn(),
-      openRightBar: vi.fn(),
     };
 
     getters = {

--- a/tests/unit/unit/components/projects/ProjectListItem.spec.js
+++ b/tests/unit/unit/components/projects/ProjectListItem.spec.js
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import { createStore } from 'vuex';
+import { createTestingPinia } from '@pinia/testing';
 
 import ProjectListItem from '@/components/projects/ProjectListItem.vue';
 import { PROJECT_COMMERCE } from '@/utils/constants';
@@ -50,7 +51,7 @@ describe('ProjectListItem.vue', () => {
 
     wrapper = shallowMount(ProjectListItem, {
       global: {
-        plugins: [store],
+        plugins: [store, createTestingPinia()],
         stubs: {
           RouterLink: RouterLinkStub,
           UnnnicIconSvg: true,


### PR DESCRIPTION
### Type of Change
- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Tests
- [ ] Chore
- [ ] Locales

### Why
The `RightBar` store was previously implemented as a Vuex module, requiring components to dispatch actions via `this.$store.dispatch('openRightBar', ...)` and `this.$store.dispatch('closeRightBar', ...)`. Migrating it to Pinia aligns it with the rest of the stores being adopted across the codebase and removes the dependency on Vuex for this concern.

### What Changed
- Converted the `RightBar` Vuex module into a Pinia store (`useRightBarStore`) using the Composition API style with `defineStore`.
- Removed `RightBar` from the Vuex store's module registry.
- Replaced all `this.$store.dispatch('openRightBar', ...)` and `this.$store.dispatch('closeRightBar', ...)` calls across `app.vue`, `ExternalSystem.vue`, `Topbar.vue`, `RightBar/Index.vue`, `orgList.vue`, `ProjectListItem.vue`, and `projects.vue` with direct Pinia action calls via `mapActions` or `rightBarStore.openRightBar/closeRightBar`.
- Added unit tests for `useRightBarStore` covering initial state, `openRightBar` (incremental ID assignment and list appending), and `closeRightBar` (removal by ID and no-op for unknown IDs).
- Updated `ProjectListItem` tests to use `createTestingPinia` instead of relying on the Vuex store for `openRightBar`.